### PR TITLE
NO-JIRA: Adds relatedImage configuration in CSV

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
-    createdAt: "2025-06-11T08:43:26Z"
+    createdAt: "2025-06-13T11:06:24Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -307,20 +307,22 @@ spec:
                 env:
                 - name: OPERATOR_NAME
                   value: zero-trust-workload-identity-manager
-                - name: SPIRE_SERVER_IMAGE
+                - name: RELATED_IMAGE_SPIRE_SERVER
                   value: ghcr.io/spiffe/spire-server:1.12.0
-                - name: SPIRE_AGENT_IMAGE
+                - name: RELATED_IMAGE_SPIRE_AGENT
                   value: ghcr.io/spiffe/spire-agent:1.12.0
-                - name: SPIFFE_CSI_DRIVER_IMAGE
+                - name: RELATED_IMAGE_SPIFFE_CSI_DRIVER
                   value: ghcr.io/spiffe/spiffe-csi-driver:0.2.3
-                - name: SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE
+                - name: RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER
                   value: ghcr.io/spiffe/oidc-discovery-provider:1.12.0
-                - name: SPIRE_CONTROLLER_MANAGER_IMAGE
+                - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
                   value: ghcr.io/spiffe/spire-controller-manager:0.6.0
-                - name: SPIFFE_HELPER_IMAGE
+                - name: RELATED_IMAGE_SPIFFE_HELPER
                   value: ghcr.io/spiffe/spiffe-helper:0.9.1
-                - name: NODE_DRIVER_REGISTRAR_IMAGE
+                - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
                   value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
+                - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
+                  value: registry.access.redhat.com/ubi9:latest
                 image: openshift.io/zero-trust-workload-identity-manager:latest
                 livenessProbe:
                   httpGet:
@@ -379,4 +381,21 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
+  relatedImages:
+  - image: ghcr.io/spiffe/spire-server:1.12.0
+    name: spire-server
+  - image: ghcr.io/spiffe/spire-agent:1.12.0
+    name: spire-agent
+  - image: ghcr.io/spiffe/spiffe-csi-driver:0.2.3
+    name: spiffe-csi-driver
+  - image: ghcr.io/spiffe/oidc-discovery-provider:1.12.0
+    name: spire-oidc-discovery-provider
+  - image: ghcr.io/spiffe/spire-controller-manager:0.6.0
+    name: spire-controller-manager
+  - image: ghcr.io/spiffe/spiffe-helper:0.9.1
+    name: spiffe-helper
+  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
+    name: node-driver-registrar
+  - image: registry.access.redhat.com/ubi9:latest
+    name: spiffe-csi-init-container
   version: 0.1.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,20 +62,22 @@ spec:
         env:
         - name: OPERATOR_NAME
           value: zero-trust-workload-identity-manager
-        - name: SPIRE_SERVER_IMAGE
+        - name: RELATED_IMAGE_SPIRE_SERVER
           value: ghcr.io/spiffe/spire-server:1.12.0
-        - name: SPIRE_AGENT_IMAGE
+        - name: RELATED_IMAGE_SPIRE_AGENT
           value: ghcr.io/spiffe/spire-agent:1.12.0
-        - name: SPIFFE_CSI_DRIVER_IMAGE
+        - name: RELATED_IMAGE_SPIFFE_CSI_DRIVER
           value: ghcr.io/spiffe/spiffe-csi-driver:0.2.3
-        - name: SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE
+        - name: RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER
           value: ghcr.io/spiffe/oidc-discovery-provider:1.12.0
-        - name: SPIRE_CONTROLLER_MANAGER_IMAGE
+        - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
           value: ghcr.io/spiffe/spire-controller-manager:0.6.0
-        - name: SPIFFE_HELPER_IMAGE
+        - name: RELATED_IMAGE_SPIFFE_HELPER
           value: ghcr.io/spiffe/spiffe-helper:0.9.1
-        - name: NODE_DRIVER_REGISTRAR_IMAGE
+        - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
           value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
+        - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
+          value: registry.access.redhat.com/ubi9:latest
         image: controller:latest
         name: manager
         securityContext:

--- a/pkg/controller/spiffe-csi-driver/daemonset.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset.go
@@ -51,7 +51,7 @@ func generateSpiffeCsiDriverDaemonSet(config v1alpha1.SpiffeCSIDriverSpec) *apps
 					InitContainers: []corev1.Container{
 						{
 							Name:  "set-context",
-							Image: "registry.access.redhat.com/ubi9:latest",
+							Image: utils.GetSpiffeCsiInitContainerImage(),
 							Command: []string{
 								"chcon", "-Rvt", "container_file_t", "spire-agent-socket/",
 							},

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -45,11 +45,12 @@ const (
 	SpireControllerManagerValidatingWebhookConfigurationAssetName = "spire-controller-manager/spire-controller-manager-webhook-validating-webhook.yaml"
 
 	// Image Reference
-	SpireServerImageEnv                = "SPIRE_SERVER_IMAGE"
-	SpireAgentImageEnv                 = "SPIRE_AGENT_IMAGE"
-	SpiffeCSIDriverImageEnv            = "SPIFFE_CSI_DRIVER_IMAGE"
-	SpireOIDCDiscoveryProviderImageEnv = "SPIRE_OIDC_DISCOVERY_PROVIDER_IMAGE"
-	SpireControllerManagerImageEnv     = "SPIRE_CONTROLLER_MANAGER_IMAGE"
-	SpiffeHelperImageEnv               = "SPIFFE_HELPER_IMAGE"
-	NodeDriverRegistrarImageEnv        = "NODE_DRIVER_REGISTRAR_IMAGE"
+	SpireServerImageEnv                = "RELATED_IMAGE_SPIRE_SERVER"
+	SpireAgentImageEnv                 = "RELATED_IMAGE_SPIRE_AGENT"
+	SpiffeCSIDriverImageEnv            = "RELATED_IMAGE_SPIFFE_CSI_DRIVER"
+	SpireOIDCDiscoveryProviderImageEnv = "RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER"
+	SpireControllerManagerImageEnv     = "RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER"
+	SpiffeHelperImageEnv               = "RELATED_IMAGE_SPIFFE_HELPER"
+	NodeDriverRegistrarImageEnv        = "RELATED_IMAGE_NODE_DRIVER_REGISTRAR"
+	SpiffeCSIInitContainerImageEnv     = "RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER"
 )

--- a/pkg/controller/utils/relatedImages.go
+++ b/pkg/controller/utils/relatedImages.go
@@ -57,3 +57,11 @@ func GetNodeDriverRegistrarImage() string {
 	}
 	return nodeDriverRegistrarImage
 }
+
+func GetSpiffeCsiInitContainerImage() string {
+	containerImage := os.Getenv(SpiffeCSIInitContainerImageEnv)
+	if containerImage == "" {
+		return "registry.access.redhat.com/ubi9:latest"
+	}
+	return containerImage
+}


### PR DESCRIPTION
This PR adds the related image config in the operator CSV, which gets replaced by the konflux bundle build.
Needed them, which eventually gets listed under console