### PR TITLE
SPIRE-109 e2e test case for SPIFFE CSI Driver

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,6 +19,8 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,6 +29,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
@@ -222,4 +225,236 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpireAgentDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
 		})
 	})
+
+	Context("when creating a spiffe csi object", func() {
+		It("should create a healthy spiffe csi driver daemonset", func() {
+			By("Creating spiffe csi driver object")
+			spiffeCsi := &operatorv1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: operatorv1alpha1.SpiffeCSIDriverSpec{},
+			}
+			err := k8sClient.Create(testCtx, spiffeCsi)
+			Expect(err).NotTo(HaveOccurred(), "failed to create spiffe csi object")
+
+			By("Waiting for all resource generation conditions in spiffe csi object to be True")
+			conditionTypes := []string{
+				"SpiffeCSISCCGeneration",
+				"SpiffeCSIDaemonSetGeneration",
+			}
+			cr := &operatorv1alpha1.SpiffeCSIDriver{}
+			utils.WaitForCRConditionsTrue(testCtx, k8sClient, cr, conditionTypes, utils.ShortTimeout)
+
+			By("Waiting for SPIRE CSI DaemonSet to become Available")
+			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
+		})
+
+		It("SPIFFE CSI Driver containers resources can be configured through SpiffeCSIDriver CR", func() {
+			By("Getting spiffe csi object")
+			spiffeCsi := &operatorv1alpha1.SpiffeCSIDriver{}
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "cluster"}, spiffeCsi)
+			Expect(err).NotTo(HaveOccurred(), "failed to get spiffe csi object")
+
+			// record initial generation of the DaemonSet before updating SpireAgent object
+			daemonset, err := clientset.AppsV1().DaemonSets(utils.OperatorNamespace).Get(testCtx, utils.SpireCSIDriverDaemonSetName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			initialGen := daemonset.Generation
+
+			By("Patching spiffe csi object with resource specifications")
+			expectedResources := &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+			}
+
+			spiffeCsi.Spec.Resources = expectedResources
+			err = k8sClient.Update(testCtx, spiffeCsi)
+			Expect(err).NotTo(HaveOccurred(), "failed to patch SpireAgent object with resources")
+			DeferCleanup(func(ctx context.Context) {
+				By("Resetting spiffe csi resources modification")
+				agent := &operatorv1alpha1.SpireAgent{}
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, agent); err == nil {
+					agent.Spec.Resources = nil
+					k8sClient.Update(ctx, agent)
+				}
+			})
+
+			By("Restarting operator Pod") // TODO: remove this step once SPIRE-68 is fixed
+			err = clientset.CoreV1().Pods(utils.OperatorNamespace).DeleteCollection(testCtx, metav1.DeleteOptions{}, metav1.ListOptions{
+				LabelSelector: utils.OperatorLabelSelector,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for spiife csi DaemonSet rolling update to start")
+			utils.WaitForDaemonSetRollingUpdate(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, initialGen, utils.DefaultTimeout)
+
+			By("Waiting for spiffe CSI DaemonSet to become Available")
+			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
+
+			By("Verifying if spiffe CSI Pods have the expected resource limits and requests")
+			pods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{LabelSelector: utils.SpiffeCsiDriverPodLabel})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			utils.VerifyContainerResources(pods.Items, expectedResources)
+		})
+
+		It("Spiffe csi nodeSelector and tolerations can be configured through CR", func() {
+			By("Getting SpireAgent object")
+			spiffeCsi := &operatorv1alpha1.SpiffeCSIDriver{}
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "cluster"}, spiffeCsi)
+			Expect(err).NotTo(HaveOccurred(), "failed to get spiffe csi object")
+
+			// record initial generation of the DaemonSet before updating SpireAgent object
+			daemonset, err := clientset.AppsV1().DaemonSets(utils.OperatorNamespace).Get(testCtx, utils.SpireCSIDriverDaemonSetName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			initialGen := daemonset.Generation
+
+			By("Patching spiffe csi object with nodeSelector and tolerations to schedule pods on control-plane nodes")
+			expectedNodeSelector := map[string]string{
+				"node-role.kubernetes.io/control-plane": "",
+			}
+			expectedToleration := []*corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}
+
+			spiffeCsi.Spec.NodeSelector = expectedNodeSelector
+			spiffeCsi.Spec.Tolerations = expectedToleration
+			err = k8sClient.Update(testCtx, spiffeCsi)
+			Expect(err).NotTo(HaveOccurred(), "failed to patch spiffe csi object with nodeSelector and tolerations")
+			DeferCleanup(func(ctx context.Context) {
+				By("Resetting spiffe csi nodeSelector and tolerations modification")
+				agent := &operatorv1alpha1.SpireAgent{}
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, agent); err == nil {
+					agent.Spec.NodeSelector = nil
+					agent.Spec.Tolerations = nil
+					k8sClient.Update(ctx, agent)
+				}
+			})
+
+			By("Restarting operator Pod")
+			err = clientset.CoreV1().Pods(utils.OperatorNamespace).DeleteCollection(testCtx, metav1.DeleteOptions{}, metav1.ListOptions{
+				LabelSelector: utils.OperatorLabelSelector,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for spiffi csi DaemonSet rolling update to start")
+			utils.WaitForDaemonSetRollingUpdate(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, initialGen, utils.ShortTimeout)
+
+			By("Waiting for spiffi csi DaemonSet to become Available")
+			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
+
+			By("Verifying if spiffi csi Pods have been scheduled to Nodes with required labels")
+			pods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{LabelSelector: utils.SpiffeCsiDriverPodLabel})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			utils.VerifyPodScheduling(testCtx, clientset, pods.Items, expectedNodeSelector)
+
+			By("Verifying if spiffe csi Pods tolerate Node taints correctly")
+			utils.VerifyPodTolerations(testCtx, clientset, pods.Items, expectedToleration)
+		})
+
+		It("Spiffe csi affinity can be configured through CR", func() {
+			By("Retrieving any Spiffe csi Pod and its Node for affinity testing")
+			pods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{LabelSelector: utils.SpiffeCsiDriverPodLabel})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			spireAgentPod := pods.Items[0]
+			targetNodeName := spireAgentPod.Spec.NodeName
+			fmt.Fprintf(GinkgoWriter, "will use node '%s' as target\n", targetNodeName)
+
+			By("Labeling the target Node with test label to simulate NodeAffinity")
+			testLabelKey := "test.spire.agent/node-affinity"
+			testLabelValue := "true"
+
+			patchData := fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, testLabelKey, testLabelValue)
+			_, err = clientset.CoreV1().Nodes().Patch(testCtx, targetNodeName, types.StrategicMergePatchType, []byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to label node '%s'", targetNodeName)
+			DeferCleanup(func(ctx context.Context) {
+				By("Removing test label from Node")
+				patchData := fmt.Sprintf(`{"metadata":{"labels":{"%s":null}}}`, testLabelKey)
+				clientset.CoreV1().Nodes().Patch(ctx, targetNodeName, types.StrategicMergePatchType, []byte(patchData), metav1.PatchOptions{})
+			})
+
+			By("Getting spiffe csi object")
+			spireAgent := &operatorv1alpha1.SpiffeCSIDriver{}
+			err = k8sClient.Get(testCtx, client.ObjectKey{Name: "cluster"}, spireAgent)
+			Expect(err).NotTo(HaveOccurred(), "failed to get spiffe csi object")
+
+			// record initial generation of the DaemonSet before updating SpireAgent object
+			daemonset, err := clientset.AppsV1().DaemonSets(utils.OperatorNamespace).Get(testCtx, utils.SpireCSIDriverDaemonSetName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			initialGen := daemonset.Generation
+
+			By("Patching spiffe csi object with NodeAffinity configuration")
+			expectedAffinity := &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      testLabelKey,
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{testLabelValue},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			expectedToleration := []*corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}
+
+			spireAgent.Spec.Affinity = expectedAffinity
+			spireAgent.Spec.Tolerations = expectedToleration
+			err = k8sClient.Update(testCtx, spireAgent)
+			Expect(err).NotTo(HaveOccurred(), "failed to patch spiffe csi object with affinity")
+			DeferCleanup(func(ctx context.Context) {
+				By("Resetting spiffe csi affinity modification")
+				agent := &operatorv1alpha1.SpireAgent{}
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, agent); err == nil {
+					agent.Spec.Affinity = nil
+					agent.Spec.Tolerations = nil
+					k8sClient.Update(ctx, agent)
+				}
+			})
+
+			By("Restarting operator Pod")
+			err = clientset.CoreV1().Pods(utils.OperatorNamespace).DeleteCollection(testCtx, metav1.DeleteOptions{}, metav1.ListOptions{
+				LabelSelector: utils.OperatorLabelSelector,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for spiffe csi DaemonSet rolling update to start")
+			utils.WaitForDaemonSetRollingUpdate(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, initialGen, utils.ShortTimeout)
+
+			By("Waiting for spiffe csi DaemonSet to become Available")
+			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpireCSIDriverDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
+
+			By("Verifying if spiffe csi Pod is constrained to the labeled Node")
+			newPods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{LabelSelector: utils.SpiffeCsiDriverPodLabel})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newPods.Items).To(HaveLen(1), "nodeAffinity should constrain daemonset to exactly one pod")
+			Expect(newPods.Items[0].Spec.NodeName).To(Equal(targetNodeName), "pod should be scheduled on the labeled node")
+			fmt.Fprintf(GinkgoWriter, "pod has been constrained to labeled node '%s'\n", targetNodeName)
+		})
+
+	})
+
 })

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -23,8 +23,10 @@ const (
 	OperatorDeploymentName = "zero-trust-workload-identity-manager-controller-manager"
 	OperatorLabelSelector  = "name=zero-trust-workload-identity-manager"
 
-	SpireServerStatefulSetName = "spire-server"
-	SpireAgentDaemonSetName    = "spire-agent"
+	SpireServerStatefulSetName  = "spire-server"
+	SpireAgentDaemonSetName     = "spire-agent"
+	SpireCSIDriverDaemonSetName = "spire-spiffe-csi-driver"
+	SpiffeCsiDriverPodLabel     = "app.kubernetes.io/name=spiffe-csi-driver"
 
 	DefaultInterval = 10 * time.Second
 	ShortInterval   = 5 * time.Second


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded end-to-end coverage for Spiffe CSI Driver CR-driven configuration: creation/readiness checks, rolling updates, container resource requests/limits, nodeSelector/tolerations, and node affinity, including cleanup.
  - Enhanced test utilities to wait for DaemonSet rolling updates and verify pod scheduling, tolerations, and container resources.
  - Minor logging improvements to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->