### PR TITLE
SPIRE-149: Adds validating webhooks to validate the ZTWIM APIs fields.

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager-webhook-service_v1_service.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager-webhook-service_v1_service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-certs
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: zero-trust-workload-identity-manager
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: zero-trust-workload-identity-manager
+    name: zero-trust-workload-identity-manager
+  name: zero-trust-workload-identity-manager-webhook-service
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    name: zero-trust-workload-identity-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2025-06-14T09:05:02Z"
+    createdAt: "2025-08-18T06:26:20Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -331,6 +331,10 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -349,12 +353,21 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: zero-trust-workload-identity-manager-controller-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-certs
     strategy: deployment
   installModes:
   - supported: true
@@ -399,3 +412,64 @@ spec:
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container
   version: 0.1.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: zero-trust-workload-identity-manager-controller-manager
+    failurePolicy: Fail
+    generateName: spireagent.operator.openshift.io
+    rules:
+    - apiGroups:
+      - operator.openshift.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - spireagents
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-operator-openshift-io-v1alpha1-spireagent
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: zero-trust-workload-identity-manager-controller-manager
+    failurePolicy: Fail
+    generateName: spireoidcdiscoveryprovider.operator.openshift.io
+    rules:
+    - apiGroups:
+      - operator.openshift.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - spireoidcdiscoveryproviders
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-operator-openshift-io-v1alpha1-spireoidcdiscoveryprovider
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: zero-trust-workload-identity-manager-controller-manager
+    failurePolicy: Fail
+    generateName: spireserver.operator.openshift.io
+    rules:
+    - apiGroups:
+      - operator.openshift.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - spireservers
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-operator-openshift-io-v1alpha1-spireserver

--- a/cmd/zero-trust-workload-identity-manager/main.go
+++ b/cmd/zero-trust-workload-identity-manager/main.go
@@ -43,6 +43,7 @@ import (
 	spireServerController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/spire-server"
 	staticResourceController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/static-resource-controller"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/operator/bootstrap"
+	webhookpkg "github.com/openshift/zero-trust-workload-identity-manager/pkg/webhook"
 
 	securityv1 "github.com/openshift/api/security/v1"
 
@@ -204,6 +205,11 @@ func main() {
 	}
 	if err = spireOIDCDiscoveryProviderControllerManager.SetupWithManager(mgr); err != nil {
 		exitOnError(err, "unable to setup spire OIDC discovery provider controller manager")
+	}
+
+	// Register validating webhooks via pkg/webhook
+	if err := webhookpkg.Register(mgr); err != nil {
+		exitOnError(err, "unable to register validating webhooks")
 	}
 
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 
-#configurations:
-#- kustomizeconfig.yaml
+configurations:
+- kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -31,9 +31,10 @@ resources:
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-certs 

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+patches:
+- path: webhookcainjection_patch.yaml
+  target:
+    group: admissionregistration.k8s.io
+    version: v1
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-operator-openshift-io-v1alpha1-spireagent
+  failurePolicy: Fail
+  name: spireagent.operator.openshift.io
+  rules:
+  - apiGroups:
+    - operator.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - spireagents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-operator-openshift-io-v1alpha1-spireoidcdiscoveryprovider
+  failurePolicy: Fail
+  name: spireoidcdiscoveryprovider.operator.openshift.io
+  rules:
+  - apiGroups:
+    - operator.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - spireoidcdiscoveryproviders
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-operator-openshift-io-v1alpha1-spireserver
+  failurePolicy: Fail
+  name: spireserver.operator.openshift.io
+  rules:
+  - apiGroups:
+    - operator.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - spireservers
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+  labels:
+    name: zero-trust-workload-identity-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: zero-trust-workload-identity-manager
+    app.kubernetes.io/part-of: zero-trust-workload-identity-manager
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-certs
+    service.beta.openshift.io/inject-cabundle: "true"
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    name: zero-trust-workload-identity-manager 

--- a/config/webhook/webhookcainjection_patch.yaml
+++ b/config/webhook/webhookcainjection_patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  value: "true" 

--- a/pkg/webhook/validators.go
+++ b/pkg/webhook/validators.go
@@ -1,0 +1,425 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
+)
+
+//+kubebuilder:webhook:path=/validate-operator-openshift-io-v1alpha1-spireserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.openshift.io,resources=spireservers,verbs=create;update,versions=v1alpha1,name=spireserver.operator.openshift.io,admissionReviewVersions=v1
+
+//+kubebuilder:webhook:path=/validate-operator-openshift-io-v1alpha1-spireagent,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.openshift.io,resources=spireagents,verbs=create;update,versions=v1alpha1,name=spireagent.operator.openshift.io,admissionReviewVersions=v1
+
+//+kubebuilder:webhook:path=/validate-operator-openshift-io-v1alpha1-spireoidcdiscoveryprovider,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.openshift.io,resources=spireoidcdiscoveryproviders,verbs=create;update,versions=v1alpha1,name=spireoidcdiscoveryprovider.operator.openshift.io,admissionReviewVersions=v1
+
+func normalizeIssuer(issuer string, trustDomain string) string {
+	if issuer == "" {
+		return fmt.Sprintf("oidc-discovery.%s", trustDomain)
+	}
+	issuer = strings.TrimPrefix(issuer, "https://")
+	issuer = strings.TrimPrefix(issuer, "http://")
+	return issuer
+}
+
+// SpireServer validator
+// +kubebuilder:object:generate=false
+type SpireServerValidator struct {
+	Client customClient.CustomCtrlClient
+}
+
+var (
+	_ webhook.CustomValidator = (*SpireServerValidator)(nil)
+	_ webhook.CustomValidator = (*SpireAgentValidator)(nil)
+	_ webhook.CustomValidator = (*SpireOIDCDiscoveryProviderValidator)(nil)
+)
+
+func (v *SpireServerValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	server, ok := obj.(*v1alpha1.SpireServer)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected a SpireServer object but got %T", obj)
+	}
+
+	var validationErrors []string
+
+	// Check SpireAgent if it exists and validate field consistency
+	var agent v1alpha1.SpireAgent
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &agent); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireAgent: %v", err)
+		}
+		// SpireAgent doesn't exist - that's allowed
+	} else {
+		// SpireAgent exists, validate consistency
+		if server.Spec.TrustDomain != agent.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireAgent trustDomain %q", server.Spec.TrustDomain, agent.Spec.TrustDomain))
+		}
+		if server.Spec.ClusterName != agent.Spec.ClusterName {
+			validationErrors = append(validationErrors, fmt.Sprintf("clusterName %q must match the existing SpireAgent clusterName %q", server.Spec.ClusterName, agent.Spec.ClusterName))
+		}
+	}
+
+	// Check SpireOIDCDiscoveryProvider if it exists and validate field consistency
+	var oidc v1alpha1.SpireOIDCDiscoveryProvider
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &oidc); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireOIDCDiscoveryProvider: %v", err)
+		}
+		// SpireOIDCDiscoveryProvider doesn't exist - that's allowed
+	} else {
+		// SpireOIDCDiscoveryProvider exists, validate consistency
+		if server.Spec.TrustDomain != oidc.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireOIDCDiscoveryProvider trustDomain %q", server.Spec.TrustDomain, oidc.Spec.TrustDomain))
+		}
+		// Validate JwtIssuer consistency
+		serverIssuer := normalizeIssuer(server.Spec.JwtIssuer, server.Spec.TrustDomain)
+		oidcIssuer := normalizeIssuer(oidc.Spec.JwtIssuer, oidc.Spec.TrustDomain)
+		if serverIssuer != oidcIssuer {
+			validationErrors = append(validationErrors, fmt.Sprintf("jwtIssuer %q (normalized: %q) must match the existing SpireOIDCDiscoveryProvider jwtIssuer (normalized: %q)", server.Spec.JwtIssuer, serverIssuer, oidcIssuer))
+		}
+	}
+
+	// Return first validation error if any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation failed: SpireServer %s. Please update the SpireServer configuration", validationErrors[0])
+	}
+
+	return nil, nil
+}
+
+func (v *SpireServerValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	oldServer, ok := oldObj.(*v1alpha1.SpireServer)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected old SpireServer object but got %T", oldObj)
+	}
+	newServer, ok := newObj.(*v1alpha1.SpireServer)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected new SpireServer object but got %T", newObj)
+	}
+	// Immutability: trustDomain and clusterName
+	if oldServer.Spec.TrustDomain != newServer.Spec.TrustDomain {
+		return nil, fmt.Errorf("validation failed: trustDomain field is immutable and cannot be changed from %q to %q. Please create a new SpireServer resource instead", oldServer.Spec.TrustDomain, newServer.Spec.TrustDomain)
+	}
+	if oldServer.Spec.ClusterName != newServer.Spec.ClusterName {
+		return nil, fmt.Errorf("validation failed: clusterName field is immutable and cannot be changed from %q to %q. Please create a new SpireServer resource instead", oldServer.Spec.ClusterName, newServer.Spec.ClusterName)
+	}
+
+	var validationErrors []string
+
+	// Check SpireAgent if it exists and validate field consistency with the new values
+	var agent v1alpha1.SpireAgent
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &agent); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireAgent: %v", err)
+		}
+		// SpireAgent doesn't exist - that's allowed
+	} else {
+		// SpireAgent exists, validate consistency with new server values
+		if newServer.Spec.TrustDomain != agent.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireAgent trustDomain %q", newServer.Spec.TrustDomain, agent.Spec.TrustDomain))
+		}
+		if newServer.Spec.ClusterName != agent.Spec.ClusterName {
+			validationErrors = append(validationErrors, fmt.Sprintf("clusterName %q must match the existing SpireAgent clusterName %q", newServer.Spec.ClusterName, agent.Spec.ClusterName))
+		}
+	}
+
+	// Check SpireOIDCDiscoveryProvider if it exists and validate field consistency with the new values
+	var oidc v1alpha1.SpireOIDCDiscoveryProvider
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &oidc); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireOIDCDiscoveryProvider: %v", err)
+		}
+		// SpireOIDCDiscoveryProvider doesn't exist - that's allowed
+	} else {
+		// SpireOIDCDiscoveryProvider exists, validate consistency with new server values
+		if newServer.Spec.TrustDomain != oidc.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireOIDCDiscoveryProvider trustDomain %q", newServer.Spec.TrustDomain, oidc.Spec.TrustDomain))
+		}
+		// Validate JwtIssuer consistency with new server values
+		newServerIssuer := normalizeIssuer(newServer.Spec.JwtIssuer, newServer.Spec.TrustDomain)
+		oidcIssuer := normalizeIssuer(oidc.Spec.JwtIssuer, oidc.Spec.TrustDomain)
+		if newServerIssuer != oidcIssuer {
+			validationErrors = append(validationErrors, fmt.Sprintf("jwtIssuer %q (normalized: %q) must match the existing SpireOIDCDiscoveryProvider jwtIssuer (normalized: %q)", newServer.Spec.JwtIssuer, newServerIssuer, oidcIssuer))
+		}
+	}
+
+	// Return first validation error if any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation failed: SpireServer update %s. Please update the SpireServer configuration", validationErrors[0])
+	}
+
+	return nil, nil
+}
+
+func (v *SpireServerValidator) ValidateDelete(context.Context, runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// SpireAgent validator
+// +kubebuilder:object:generate=false
+type SpireAgentValidator struct {
+	Client customClient.CustomCtrlClient
+}
+
+func (v *SpireAgentValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	agent, ok := obj.(*v1alpha1.SpireAgent)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected a SpireAgent object but got %T", obj)
+	}
+
+	var validationErrors []string
+
+	// Check SpireServer if it exists and validate field consistency
+	var server v1alpha1.SpireServer
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &server); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireServer: %v", err)
+		}
+		// SpireServer doesn't exist - that's allowed
+	} else {
+		// SpireServer exists, validate field consistency
+		if agent.Spec.TrustDomain != server.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireServer trustDomain %q", agent.Spec.TrustDomain, server.Spec.TrustDomain))
+		}
+		if agent.Spec.ClusterName != server.Spec.ClusterName {
+			validationErrors = append(validationErrors, fmt.Sprintf("clusterName %q must match the existing SpireServer clusterName %q", agent.Spec.ClusterName, server.Spec.ClusterName))
+		}
+	}
+
+	// Check SpireOIDCDiscoveryProvider if it exists and validate field consistency
+	var oidc v1alpha1.SpireOIDCDiscoveryProvider
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &oidc); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireOIDCDiscoveryProvider: %v", err)
+		}
+		// SpireOIDCDiscoveryProvider doesn't exist - that's allowed
+	} else {
+		// SpireOIDCDiscoveryProvider exists, validate trustDomain consistency
+		if agent.Spec.TrustDomain != oidc.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireOIDCDiscoveryProvider trustDomain %q", agent.Spec.TrustDomain, oidc.Spec.TrustDomain))
+		}
+	}
+
+	// Return first validation error if any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation failed: SpireAgent %s. Please update the SpireAgent configuration", validationErrors[0])
+	}
+
+	return nil, nil
+}
+
+func (v *SpireAgentValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	oldAgent, ok := oldObj.(*v1alpha1.SpireAgent)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected old SpireAgent object but got %T", oldObj)
+	}
+	newAgent, ok := newObj.(*v1alpha1.SpireAgent)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected new SpireAgent object but got %T", newObj)
+	}
+	// Immutability: trustDomain and clusterName
+	if oldAgent.Spec.TrustDomain != newAgent.Spec.TrustDomain {
+		return nil, fmt.Errorf("validation failed: trustDomain field is immutable and cannot be changed from %q to %q. Please create a new SpireAgent resource instead", oldAgent.Spec.TrustDomain, newAgent.Spec.TrustDomain)
+	}
+	if oldAgent.Spec.ClusterName != newAgent.Spec.ClusterName {
+		return nil, fmt.Errorf("validation failed: clusterName field is immutable and cannot be changed from %q to %q. Please create a new SpireAgent resource instead", oldAgent.Spec.ClusterName, newAgent.Spec.ClusterName)
+	}
+
+	var validationErrors []string
+
+	// Check SpireServer if it exists and validate field consistency with the new values
+	var server v1alpha1.SpireServer
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &server); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireServer: %v", err)
+		}
+		// SpireServer doesn't exist - that's allowed
+	} else {
+		// SpireServer exists, validate field consistency with new agent values
+		if newAgent.Spec.TrustDomain != server.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireServer trustDomain %q", newAgent.Spec.TrustDomain, server.Spec.TrustDomain))
+		}
+		if newAgent.Spec.ClusterName != server.Spec.ClusterName {
+			validationErrors = append(validationErrors, fmt.Sprintf("clusterName %q must match the existing SpireServer clusterName %q", newAgent.Spec.ClusterName, server.Spec.ClusterName))
+		}
+	}
+
+	// Check SpireOIDCDiscoveryProvider if it exists and validate field consistency with the new values
+	var oidc v1alpha1.SpireOIDCDiscoveryProvider
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &oidc); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireOIDCDiscoveryProvider: %v", err)
+		}
+		// SpireOIDCDiscoveryProvider doesn't exist - that's allowed
+	} else {
+		// SpireOIDCDiscoveryProvider exists, validate trustDomain consistency with new agent values
+		if newAgent.Spec.TrustDomain != oidc.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireOIDCDiscoveryProvider trustDomain %q", newAgent.Spec.TrustDomain, oidc.Spec.TrustDomain))
+		}
+	}
+
+	// Return first validation error if any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation failed: SpireAgent update %s. Please update the SpireAgent configuration", validationErrors[0])
+	}
+
+	return nil, nil
+}
+
+func (v *SpireAgentValidator) ValidateDelete(context.Context, runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// OIDC validator
+// +kubebuilder:object:generate=false
+type SpireOIDCDiscoveryProviderValidator struct {
+	Client customClient.CustomCtrlClient
+}
+
+func (v *SpireOIDCDiscoveryProviderValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	oidc, ok := obj.(*v1alpha1.SpireOIDCDiscoveryProvider)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected a SpireOIDCDiscoveryProvider object but got %T", obj)
+	}
+
+	var validationErrors []string
+
+	// Check SpireServer if it exists and validate field consistency (but don't require it to exist)
+	var server v1alpha1.SpireServer
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &server); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireServer: %v", err)
+		}
+		// SpireServer doesn't exist - that's allowed
+	} else {
+		// SpireServer exists, validate trustDomain consistency
+		if oidc.Spec.TrustDomain != server.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireServer trustDomain %q", oidc.Spec.TrustDomain, server.Spec.TrustDomain))
+		}
+		// Validate JwtIssuer consistency with SpireServer
+		serverIssuer := normalizeIssuer(server.Spec.JwtIssuer, server.Spec.TrustDomain)
+		oidcIssuer := normalizeIssuer(oidc.Spec.JwtIssuer, oidc.Spec.TrustDomain)
+		if serverIssuer != oidcIssuer {
+			validationErrors = append(validationErrors, fmt.Sprintf("jwtIssuer %q (normalized: %q) must match the existing SpireServer jwtIssuer (normalized: %q)", oidc.Spec.JwtIssuer, oidcIssuer, serverIssuer))
+		}
+	}
+
+	// Check SpireAgent if it exists and validate field consistency (but don't require it to exist)
+	var agent v1alpha1.SpireAgent
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &agent); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireAgent: %v", err)
+		}
+		// SpireAgent doesn't exist - that's allowed
+	} else {
+		// SpireAgent exists, validate trustDomain consistency
+		if oidc.Spec.TrustDomain != agent.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireAgent trustDomain %q", oidc.Spec.TrustDomain, agent.Spec.TrustDomain))
+		}
+	}
+
+	// Return first validation error if any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation failed: SpireOIDCDiscoveryProvider %s. Please update the SpireOIDCDiscoveryProvider configuration", validationErrors[0])
+	}
+
+	return nil, nil
+}
+
+func (v *SpireOIDCDiscoveryProviderValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	oldOIDC, ok := oldObj.(*v1alpha1.SpireOIDCDiscoveryProvider)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected old SpireOIDCDiscoveryProvider object but got %T", oldObj)
+	}
+	newOIDC, ok := newObj.(*v1alpha1.SpireOIDCDiscoveryProvider)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected new SpireOIDCDiscoveryProvider object but got %T", newObj)
+	}
+	// Immutability: trustDomain
+	if oldOIDC.Spec.TrustDomain != newOIDC.Spec.TrustDomain {
+		return nil, fmt.Errorf("validation failed: trustDomain field is immutable and cannot be changed from %q to %q. Please create a new SpireOIDCDiscoveryProvider resource instead", oldOIDC.Spec.TrustDomain, newOIDC.Spec.TrustDomain)
+	}
+
+	var validationErrors []string
+
+	// Check SpireServer if it exists and validate field consistency with the new values
+	var server v1alpha1.SpireServer
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &server); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireServer: %v", err)
+		}
+		// SpireServer doesn't exist - that's allowed
+	} else {
+		// SpireServer exists, validate consistency with new OIDC values
+		if newOIDC.Spec.TrustDomain != server.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireServer trustDomain %q", newOIDC.Spec.TrustDomain, server.Spec.TrustDomain))
+		}
+		// Validate JwtIssuer consistency with new OIDC values
+		serverIssuer := normalizeIssuer(server.Spec.JwtIssuer, server.Spec.TrustDomain)
+		newOidcIssuer := normalizeIssuer(newOIDC.Spec.JwtIssuer, newOIDC.Spec.TrustDomain)
+		if serverIssuer != newOidcIssuer {
+			validationErrors = append(validationErrors, fmt.Sprintf("jwtIssuer %q (normalized: %q) must match the existing SpireServer jwtIssuer (normalized: %q)", newOIDC.Spec.JwtIssuer, newOidcIssuer, serverIssuer))
+		}
+	}
+
+	// Check SpireAgent if it exists and validate field consistency with the new values
+	var agent v1alpha1.SpireAgent
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, &agent); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("validation failed: unable to check for existing SpireAgent: %v", err)
+		}
+		// SpireAgent doesn't exist - that's allowed
+	} else {
+		// SpireAgent exists, validate trustDomain consistency with new OIDC values
+		if newOIDC.Spec.TrustDomain != agent.Spec.TrustDomain {
+			validationErrors = append(validationErrors, fmt.Sprintf("trustDomain %q must match the existing SpireAgent trustDomain %q", newOIDC.Spec.TrustDomain, agent.Spec.TrustDomain))
+		}
+	}
+
+	// Return first validation error if any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation failed: SpireOIDCDiscoveryProvider update %s. Please update the SpireOIDCDiscoveryProvider configuration", validationErrors[0])
+	}
+
+	return nil, nil
+}
+
+func (v *SpireOIDCDiscoveryProviderValidator) ValidateDelete(context.Context, runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// Register all validators using the controllers' custom client
+func Register(mgr ctrl.Manager) error {
+	c, err := customClient.NewCustomClient(mgr)
+	if err != nil {
+		return err
+	}
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.SpireServer{}).
+		WithValidator(&SpireServerValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.SpireAgent{}).
+		WithValidator(&SpireAgentValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.SpireOIDCDiscoveryProvider{}).
+		WithValidator(&SpireOIDCDiscoveryProviderValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/webhook/validators_test.go
+++ b/pkg/webhook/validators_test.go
@@ -1,0 +1,842 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+)
+
+// MockCustomClient is a mock implementation of CustomCtrlClient
+type MockCustomClient struct {
+	mock.Mock
+}
+
+func (m *MockCustomClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	args := m.Called(ctx, key, obj)
+
+	// Only copy if we have a valid return object and no error
+	if args.Error(0) == nil && args.Get(1) != nil {
+		switch v := obj.(type) {
+		case *v1alpha1.SpireServer:
+			if server, ok := args.Get(1).(*v1alpha1.SpireServer); ok {
+				*v = *server
+			}
+		case *v1alpha1.SpireAgent:
+			if agent, ok := args.Get(1).(*v1alpha1.SpireAgent); ok {
+				*v = *agent
+			}
+		case *v1alpha1.SpireOIDCDiscoveryProvider:
+			if oidc, ok := args.Get(1).(*v1alpha1.SpireOIDCDiscoveryProvider); ok {
+				*v = *oidc
+			}
+		}
+	}
+
+	return args.Error(0)
+}
+
+// Implement remaining CustomCtrlClient interface methods as stubs
+func (m *MockCustomClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) StatusUpdate(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) UpdateWithRetry(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+func (m *MockCustomClient) Exists(ctx context.Context, key client.ObjectKey, obj client.Object) (bool, error) {
+	return false, nil
+}
+
+func (m *MockCustomClient) CreateOrUpdateObject(ctx context.Context, obj client.Object) error {
+	return nil
+}
+
+func (m *MockCustomClient) StatusUpdateWithRetry(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return nil
+}
+
+// Helper functions to create test objects
+func createSpireServer(trustDomain, clusterName, jwtIssuer string) *v1alpha1.SpireServer {
+	return &v1alpha1.SpireServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: v1alpha1.SpireServerSpec{
+			TrustDomain: trustDomain,
+			ClusterName: clusterName,
+			JwtIssuer:   jwtIssuer,
+		},
+	}
+}
+
+func createSpireAgent(trustDomain, clusterName string) *v1alpha1.SpireAgent {
+	return &v1alpha1.SpireAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: v1alpha1.SpireAgentSpec{
+			TrustDomain: trustDomain,
+			ClusterName: clusterName,
+		},
+	}
+}
+
+func createSpireOIDCDiscoveryProvider(trustDomain, jwtIssuer string) *v1alpha1.SpireOIDCDiscoveryProvider {
+	return &v1alpha1.SpireOIDCDiscoveryProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: v1alpha1.SpireOIDCDiscoveryProviderSpec{
+			TrustDomain: trustDomain,
+			JwtIssuer:   jwtIssuer,
+		},
+	}
+}
+
+// Test normalizeIssuer function
+func TestNormalizeIssuer(t *testing.T) {
+	tests := []struct {
+		name        string
+		issuer      string
+		trustDomain string
+		expected    string
+	}{
+		{
+			name:        "empty issuer returns default",
+			issuer:      "",
+			trustDomain: "example.com",
+			expected:    "oidc-discovery.example.com",
+		},
+		{
+			name:        "https prefix is stripped",
+			issuer:      "https://my-issuer.com",
+			trustDomain: "example.com",
+			expected:    "my-issuer.com",
+		},
+		{
+			name:        "http prefix is stripped",
+			issuer:      "http://my-issuer.com",
+			trustDomain: "example.com",
+			expected:    "my-issuer.com",
+		},
+		{
+			name:        "no prefix returns as is",
+			issuer:      "my-issuer.com",
+			trustDomain: "example.com",
+			expected:    "my-issuer.com",
+		},
+		{
+			name:        "both prefixes handled correctly",
+			issuer:      "https://http://my-issuer.com",
+			trustDomain: "example.com",
+			expected:    "my-issuer.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeIssuer(tt.issuer, tt.trustDomain)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Test SpireServerValidator
+func TestSpireServerValidator_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		server      *v1alpha1.SpireServer
+		agentExists bool
+		agent       *v1alpha1.SpireAgent
+		agentError  error
+		oidcExists  bool
+		oidc        *v1alpha1.SpireOIDCDiscoveryProvider
+		oidcError   error
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "successful creation - no existing resources",
+			server:      createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			agentExists: false,
+			agentError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     false,
+		},
+		{
+			name:        "successful creation - matching fields with agent",
+			server:      createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			agentExists: true,
+			agent:       createSpireAgent("example.com", "test-cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     false,
+		},
+		{
+			name:        "failed creation - trustDomain mismatch with agent",
+			server:      createSpireServer("different.com", "test-cluster", "https://issuer.com"),
+			agentExists: true,
+			agent:       createSpireAgent("example.com", "test-cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     true,
+			errMsg:      "validation failed: SpireServer trustDomain",
+		},
+		{
+			name:        "failed creation - jwtIssuer mismatch with oidc",
+			server:      createSpireServer("example.com", "test-cluster", "https://different-issuer.com"),
+			agentExists: false,
+			agentError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:  true,
+			oidc:        createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			wantErr:     true,
+			errMsg:      "validation failed: SpireServer jwtIssuer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockCustomClient{}
+			validator := &SpireServerValidator{Client: mockClient}
+
+			// Mock agent Get call
+			if tt.agentExists {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+					Return(nil, tt.agent).Once()
+			} else {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+					Return(tt.agentError, nil).Once()
+			}
+
+			// Mock oidc Get call
+			if tt.oidcExists {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+					Return(nil, tt.oidc).Once()
+			} else {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+					Return(tt.oidcError, nil).Once()
+			}
+
+			warnings, err := validator.ValidateCreate(context.Background(), tt.server)
+
+			assert.Nil(t, warnings)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSpireServerValidator_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldServer   *v1alpha1.SpireServer
+		newServer   *v1alpha1.SpireServer
+		agentExists bool
+		agent       *v1alpha1.SpireAgent
+		agentError  error
+		oidcExists  bool
+		oidc        *v1alpha1.SpireOIDCDiscoveryProvider
+		oidcError   error
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "successful update with no changes",
+			oldServer:   createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			newServer:   createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			agentExists: false,
+			agentError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     false,
+		},
+		{
+			name:        "successful update with allowed field changes",
+			oldServer:   createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			newServer:   createSpireServer("example.com", "test-cluster", "https://new-issuer.com"),
+			agentExists: false,
+			agentError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     false,
+		},
+		{
+			name:        "failed update - trustDomain changed",
+			oldServer:   createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			newServer:   createSpireServer("new-domain.com", "test-cluster", "https://issuer.com"),
+			agentExists: false,
+			agentError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     true,
+			errMsg:      "validation failed: trustDomain field is immutable and cannot be changed",
+		},
+		{
+			name:        "failed update - clusterName changed",
+			oldServer:   createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			newServer:   createSpireServer("example.com", "new-cluster", "https://issuer.com"),
+			agentExists: false,
+			agentError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     true,
+			errMsg:      "validation failed: clusterName field is immutable and cannot be changed",
+		},
+		{
+			name:        "failed update - trustDomain mismatch with existing agent",
+			oldServer:   createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			newServer:   createSpireServer("example.com", "test-cluster", "https://new-issuer.com"),
+			agentExists: true,
+			agent:       createSpireAgent("different.com", "test-cluster"),
+			oidcExists:  false,
+			oidcError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:     true,
+			errMsg:      "validation failed: SpireServer update trustDomain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockCustomClient{}
+			validator := &SpireServerValidator{Client: mockClient}
+
+			// Only set up mocks if the validation won't fail on immutability
+			isImmutabilityError := (tt.oldServer.Spec.TrustDomain != tt.newServer.Spec.TrustDomain) ||
+				(tt.oldServer.Spec.ClusterName != tt.newServer.Spec.ClusterName)
+
+			if !isImmutabilityError {
+				// Mock agent Get call
+				if tt.agentExists {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+						Return(nil, tt.agent).Once()
+				} else {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+						Return(tt.agentError, nil).Once()
+				}
+
+				// Mock oidc Get call
+				if tt.oidcExists {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+						Return(nil, tt.oidc).Once()
+				} else {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+						Return(tt.oidcError, nil).Once()
+				}
+			}
+
+			warnings, err := validator.ValidateUpdate(context.Background(), tt.oldServer, tt.newServer)
+
+			assert.Nil(t, warnings)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSpireServerValidator_ValidateDelete(t *testing.T) {
+	validator := &SpireServerValidator{}
+	server := createSpireServer("example.com", "test-cluster", "https://issuer.com")
+
+	warnings, err := validator.ValidateDelete(context.Background(), server)
+
+	assert.Nil(t, warnings)
+	assert.NoError(t, err, "ValidateDelete should not perform any validation for SpireServer")
+}
+
+// Test SpireAgentValidator
+func TestSpireAgentValidator_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name         string
+		agent        *v1alpha1.SpireAgent
+		serverExists bool
+		server       *v1alpha1.SpireServer
+		serverError  error
+		oidcExists   bool
+		oidc         *v1alpha1.SpireOIDCDiscoveryProvider
+		oidcError    error
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "successful creation with matching fields",
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			serverExists: true,
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "successful creation - server does not exist",
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "failed creation - trustDomain mismatch",
+			agent:        createSpireAgent("different.com", "test-cluster"),
+			serverExists: true,
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: SpireAgent trustDomain",
+		},
+		{
+			name:         "failed creation - clusterName mismatch",
+			agent:        createSpireAgent("example.com", "different-cluster"),
+			serverExists: true,
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: SpireAgent clusterName",
+		},
+		{
+			name:         "failed creation - trustDomain mismatch with OIDC",
+			agent:        createSpireAgent("different.com", "test-cluster"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:   true,
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			wantErr:      true,
+			errMsg:       "validation failed: SpireAgent trustDomain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockCustomClient{}
+			validator := &SpireAgentValidator{Client: mockClient}
+
+			if tt.serverExists {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+					Return(nil, tt.server).Once()
+			} else {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+					Return(tt.serverError, nil).Once()
+			}
+
+			if tt.oidcExists {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+					Return(nil, tt.oidc).Once()
+			} else {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+					Return(tt.oidcError, nil).Once()
+			}
+
+			warnings, err := validator.ValidateCreate(context.Background(), tt.agent)
+
+			assert.Nil(t, warnings)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSpireAgentValidator_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		oldAgent     *v1alpha1.SpireAgent
+		newAgent     *v1alpha1.SpireAgent
+		serverExists bool
+		server       *v1alpha1.SpireServer
+		serverError  error
+		oidcExists   bool
+		oidc         *v1alpha1.SpireOIDCDiscoveryProvider
+		oidcError    error
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "successful update with no changes",
+			oldAgent:     createSpireAgent("example.com", "test-cluster"),
+			newAgent:     createSpireAgent("example.com", "test-cluster"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "failed update - trustDomain changed",
+			oldAgent:     createSpireAgent("example.com", "test-cluster"),
+			newAgent:     createSpireAgent("new-domain.com", "test-cluster"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: trustDomain field is immutable and cannot be changed",
+		},
+		{
+			name:         "failed update - clusterName changed",
+			oldAgent:     createSpireAgent("example.com", "test-cluster"),
+			newAgent:     createSpireAgent("example.com", "new-cluster"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: clusterName field is immutable and cannot be changed",
+		},
+		{
+			name:         "failed update - trustDomain mismatch with existing server",
+			oldAgent:     createSpireAgent("example.com", "test-cluster"),
+			newAgent:     createSpireAgent("example.com", "test-cluster"),
+			serverExists: true,
+			server:       createSpireServer("different.com", "test-cluster", "https://issuer.com"),
+			oidcExists:   false,
+			oidcError:    kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: SpireAgent update trustDomain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockCustomClient{}
+			validator := &SpireAgentValidator{Client: mockClient}
+
+			// Only set up mocks if the validation won't fail on immutability
+			isImmutabilityError := (tt.oldAgent.Spec.TrustDomain != tt.newAgent.Spec.TrustDomain) ||
+				(tt.oldAgent.Spec.ClusterName != tt.newAgent.Spec.ClusterName)
+
+			if !isImmutabilityError {
+				// Mock server Get call
+				if tt.serverExists {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+						Return(nil, tt.server).Once()
+				} else {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+						Return(tt.serverError, nil).Once()
+				}
+
+				// Mock oidc Get call
+				if tt.oidcExists {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+						Return(nil, tt.oidc).Once()
+				} else {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireOIDCDiscoveryProvider")).
+						Return(tt.oidcError, nil).Once()
+				}
+			}
+
+			warnings, err := validator.ValidateUpdate(context.Background(), tt.oldAgent, tt.newAgent)
+
+			assert.Nil(t, warnings)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSpireAgentValidator_ValidateDelete(t *testing.T) {
+	validator := &SpireAgentValidator{}
+	agent := createSpireAgent("example.com", "test-cluster")
+
+	warnings, err := validator.ValidateDelete(context.Background(), agent)
+
+	assert.Nil(t, warnings)
+	assert.NoError(t, err, "ValidateDelete should not perform any validation for SpireAgent")
+}
+
+// Test SpireOIDCDiscoveryProviderValidator
+func TestSpireOIDCDiscoveryProviderValidator_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name         string
+		oidc         *v1alpha1.SpireOIDCDiscoveryProvider
+		server       *v1alpha1.SpireServer
+		serverExists bool
+		serverError  error
+		agent        *v1alpha1.SpireAgent
+		agentExists  bool
+		agentError   error
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "successful creation with matching fields",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			serverExists: true,
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			agentExists:  true,
+			wantErr:      false,
+		},
+		{
+			name:         "successful creation with normalized issuer matching",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "issuer.com"),
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			serverExists: true,
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			agentExists:  true,
+			wantErr:      false,
+		},
+		{
+			name:         "successful creation with default issuer",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", ""),
+			server:       createSpireServer("example.com", "test-cluster", ""),
+			serverExists: true,
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			agentExists:  true,
+			wantErr:      false,
+		},
+		{
+			name:         "successful creation - server does not exist",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			agentExists:  false,
+			agentError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "successful creation - agent does not exist",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			serverExists: true,
+			agentExists:  false,
+			agentError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "failed creation - trustDomain mismatch with server",
+			oidc:         createSpireOIDCDiscoveryProvider("different.com", "https://issuer.com"),
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			serverExists: true,
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			agentExists:  true,
+			wantErr:      true,
+			errMsg:       "validation failed: SpireOIDCDiscoveryProvider trustDomain",
+		},
+		{
+			name:         "failed creation - trustDomain mismatch with agent",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			serverExists: true,
+			agent:        createSpireAgent("different.com", "test-cluster"),
+			agentExists:  true,
+			wantErr:      true,
+			errMsg:       "validation failed: SpireOIDCDiscoveryProvider trustDomain",
+		},
+		{
+			name:         "failed creation - jwtIssuer mismatch",
+			oidc:         createSpireOIDCDiscoveryProvider("example.com", "https://different-issuer.com"),
+			server:       createSpireServer("example.com", "test-cluster", "https://issuer.com"),
+			serverExists: true,
+			agent:        createSpireAgent("example.com", "test-cluster"),
+			agentExists:  true,
+			wantErr:      true,
+			errMsg:       "validation failed: SpireOIDCDiscoveryProvider jwtIssuer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockCustomClient{}
+			validator := &SpireOIDCDiscoveryProviderValidator{Client: mockClient}
+
+			// Mock server Get call
+			if tt.serverExists {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+					Return(nil, tt.server).Once()
+			} else {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+					Return(tt.serverError, nil).Once()
+			}
+
+			// Mock agent Get call - always called now since we check agent even if server doesn't exist
+			if tt.agentExists {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+					Return(nil, tt.agent).Once()
+			} else {
+				mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+					Return(tt.agentError, nil).Once()
+			}
+
+			warnings, err := validator.ValidateCreate(context.Background(), tt.oidc)
+
+			assert.Nil(t, warnings)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSpireOIDCDiscoveryProviderValidator_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		oldOIDC      *v1alpha1.SpireOIDCDiscoveryProvider
+		newOIDC      *v1alpha1.SpireOIDCDiscoveryProvider
+		serverExists bool
+		server       *v1alpha1.SpireServer
+		serverError  error
+		agentExists  bool
+		agent        *v1alpha1.SpireAgent
+		agentError   error
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "successful update with no changes",
+			oldOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			newOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			agentExists:  false,
+			agentError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "successful update with allowed field changes",
+			oldOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			newOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://new-issuer.com"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			agentExists:  false,
+			agentError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      false,
+		},
+		{
+			name:         "failed update - trustDomain changed",
+			oldOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			newOIDC:      createSpireOIDCDiscoveryProvider("new-domain.com", "https://issuer.com"),
+			serverExists: false,
+			serverError:  kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			agentExists:  false,
+			agentError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: trustDomain field is immutable and cannot be changed",
+		},
+		{
+			name:         "failed update - trustDomain mismatch with existing server",
+			oldOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com"),
+			newOIDC:      createSpireOIDCDiscoveryProvider("example.com", "https://new-issuer.com"),
+			serverExists: true,
+			server:       createSpireServer("different.com", "test-cluster", "https://issuer.com"),
+			agentExists:  false,
+			agentError:   kerrors.NewNotFound(schema.GroupResource{}, "cluster"),
+			wantErr:      true,
+			errMsg:       "validation failed: SpireOIDCDiscoveryProvider update trustDomain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockCustomClient{}
+			validator := &SpireOIDCDiscoveryProviderValidator{Client: mockClient}
+
+			// Only set up mocks if the validation won't fail on immutability
+			isImmutabilityError := (tt.oldOIDC.Spec.TrustDomain != tt.newOIDC.Spec.TrustDomain)
+
+			if !isImmutabilityError {
+				// Mock server Get call
+				if tt.serverExists {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+						Return(nil, tt.server).Once()
+				} else {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireServer")).
+						Return(tt.serverError, nil).Once()
+				}
+
+				// Mock agent Get call
+				if tt.agentExists {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+						Return(nil, tt.agent).Once()
+				} else {
+					mockClient.On("Get", mock.Anything, types.NamespacedName{Name: "cluster"}, mock.AnythingOfType("*v1alpha1.SpireAgent")).
+						Return(tt.agentError, nil).Once()
+				}
+			}
+
+			warnings, err := validator.ValidateUpdate(context.Background(), tt.oldOIDC, tt.newOIDC)
+
+			assert.Nil(t, warnings)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSpireOIDCDiscoveryProviderValidator_ValidateDelete(t *testing.T) {
+	validator := &SpireOIDCDiscoveryProviderValidator{}
+	oidc := createSpireOIDCDiscoveryProvider("example.com", "https://issuer.com")
+
+	warnings, err := validator.ValidateDelete(context.Background(), oidc)
+
+	assert.Nil(t, warnings)
+	assert.NoError(t, err, "ValidateDelete should not perform any validation for SpireOIDCDiscoveryProvider")
+}


### PR DESCRIPTION
Implements validating webhooks to enforce consistency across SpireServer, SpireAgent, and SpireOIDCDiscoveryProvider resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces validating webhooks for SpireServer, SpireAgent, and SpireOIDCDiscoveryProvider.
  - Enforces cross-resource consistency (trust domain, cluster name, JWT issuer) and immutability on updates.
  - Webhooks use failurePolicy: Fail and admissionReviewVersions: v1.

- Chores
  - Enables webhook components and service exposure with TLS via platform-managed serving certificates and CA bundle injection.
  - Activates necessary kustomize configurations and patches for webhook deployment.
  - Adds readiness probe to improve health reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->