### PR TITLE
Adds the pause reconcilation flag to allow user to update the configurations which wont be reconciled back by the operator

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2025-06-14T09:05:02Z"
+    createdAt: "2025-08-19T10:19:59Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -302,11 +302,13 @@ spec:
               containers:
               - args:
                 - --health-probe-bind-address=:8081
+                - --unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)
                 command:
                 - /usr/bin/zero-trust-workload-identity-manager
                 env:
                 - name: OPERATOR_NAME
                   value: zero-trust-workload-identity-manager
+                - name: UNSUPPORTED_ADDON_FEATURES
                 - name: RELATED_IMAGE_SPIRE_SERVER
                   value: ghcr.io/spiffe/spire-server:1.12.0
                 - name: RELATED_IMAGE_SPIRE_AGENT

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,9 +59,12 @@ spec:
         - /usr/bin/zero-trust-workload-identity-manager
         args:
           - --health-probe-bind-address=:8081
+          - --unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)
         env:
         - name: OPERATOR_NAME
           value: zero-trust-workload-identity-manager
+        - name: UNSUPPORTED_ADDON_FEATURES
+          value: ""
         - name: RELATED_IMAGE_SPIRE_SERVER
           value: ghcr.io/spiffe/spire-server:1.12.0
         - name: RELATED_IMAGE_SPIRE_AGENT

--- a/pkg/controller/spiffe-csi-driver/controller.go
+++ b/pkg/controller/spiffe-csi-driver/controller.go
@@ -68,6 +68,10 @@ func New(mgr ctrl.Manager) (*SpiffeCsiReconciler, error) {
 }
 
 func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if utils.IsReconciliationPaused() {
+		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+		return ctrl.Result{}, nil
+	}
 	var spiffeCSIDriver v1alpha1.SpiffeCSIDriver
 	if err := r.ctrlClient.Get(ctx, req.NamespacedName, &spiffeCSIDriver); err != nil {
 		if kerrors.IsNotFound(err) {

--- a/pkg/controller/spiffe-csi-driver/controller.go
+++ b/pkg/controller/spiffe-csi-driver/controller.go
@@ -3,8 +3,10 @@ package spiffe_csi_driver
 import (
 	"context"
 	"fmt"
+
 	securityv1 "github.com/openshift/api/security/v1"
 	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/featuregate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -68,8 +70,8 @@ func New(mgr ctrl.Manager) (*SpiffeCsiReconciler, error) {
 }
 
 func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if utils.IsReconciliationPaused() {
-		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+	if utils.IsAutoReconcileDisabled() {
+		r.log.Info("Auto-reconciliation disabled to allow manual management", "feature", featuregate.DisableAutoReconcileFeature)
 		return ctrl.Result{}, nil
 	}
 	var spiffeCSIDriver v1alpha1.SpiffeCSIDriver

--- a/pkg/controller/spire-agent/controller.go
+++ b/pkg/controller/spire-agent/controller.go
@@ -72,6 +72,10 @@ func New(mgr ctrl.Manager) (*SpireAgentReconciler, error) {
 }
 
 func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if utils.IsReconciliationPaused() {
+		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+		return ctrl.Result{}, nil
+	}
 	var agent v1alpha1.SpireAgent
 	if err := r.ctrlClient.Get(ctx, req.NamespacedName, &agent); err != nil {
 		if kerrors.IsNotFound(err) {

--- a/pkg/controller/spire-agent/controller.go
+++ b/pkg/controller/spire-agent/controller.go
@@ -3,8 +3,7 @@ package spire_agent
 import (
 	"context"
 	"fmt"
-	securityv1 "github.com/openshift/api/security/v1"
-	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -29,8 +28,11 @@ import (
 
 	"github.com/go-logr/logr"
 
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/featuregate"
 )
 
 type reconcilerStatus struct {
@@ -72,8 +74,8 @@ func New(mgr ctrl.Manager) (*SpireAgentReconciler, error) {
 }
 
 func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if utils.IsReconciliationPaused() {
-		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+	if utils.IsAutoReconcileDisabled() {
+		r.log.Info("Auto-reconciliation disabled to allow manual management", "feature", featuregate.DisableAutoReconcileFeature)
 		return ctrl.Result{}, nil
 	}
 	var agent v1alpha1.SpireAgent

--- a/pkg/controller/spire-oidc-discovery-provider/controller.go
+++ b/pkg/controller/spire-oidc-discovery-provider/controller.go
@@ -2,10 +2,12 @@ package spire_oidc_discovery_provider
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	securityv1 "github.com/openshift/api/security/v1"
 	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/featuregate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,8 +71,8 @@ func New(mgr ctrl.Manager) (*SpireOidcDiscoveryProviderReconciler, error) {
 func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.log.Info("Reconciling SpireOIDCDiscoveryProvider controller")
 
-	if utils.IsReconciliationPaused() {
-		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+	if utils.IsAutoReconcileDisabled() {
+		r.log.Info("Auto-reconciliation disabled to allow manual management", "feature", featuregate.DisableAutoReconcileFeature)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controller/spire-oidc-discovery-provider/controller.go
+++ b/pkg/controller/spire-oidc-discovery-provider/controller.go
@@ -69,6 +69,11 @@ func New(mgr ctrl.Manager) (*SpireOidcDiscoveryProviderReconciler, error) {
 func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.log.Info("Reconciling SpireOIDCDiscoveryProvider controller")
 
+	if utils.IsReconciliationPaused() {
+		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+		return ctrl.Result{}, nil
+	}
+
 	var oidcDiscoveryProviderConfig v1alpha1.SpireOIDCDiscoveryProvider
 	if err := r.ctrlClient.Get(ctx, req.NamespacedName, &oidcDiscoveryProviderConfig); err != nil {
 		if kerrors.IsNotFound(err) {

--- a/pkg/controller/spire-server/controller.go
+++ b/pkg/controller/spire-server/controller.go
@@ -73,6 +73,10 @@ func New(mgr ctrl.Manager) (*SpireServerReconciler, error) {
 }
 
 func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if utils.IsReconciliationPaused() {
+		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+		return ctrl.Result{}, nil
+	}
 	var server v1alpha1.SpireServer
 	if err := r.ctrlClient.Get(ctx, req.NamespacedName, &server); err != nil {
 		if kerrors.IsNotFound(err) {

--- a/pkg/controller/spire-server/controller.go
+++ b/pkg/controller/spire-server/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/featuregate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,8 +74,8 @@ func New(mgr ctrl.Manager) (*SpireServerReconciler, error) {
 }
 
 func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if utils.IsReconciliationPaused() {
-		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+	if utils.IsAutoReconcileDisabled() {
+		r.log.Info("Auto-reconciliation disabled to allow manual management", "feature", featuregate.DisableAutoReconcileFeature)
 		return ctrl.Result{}, nil
 	}
 	var server v1alpha1.SpireServer

--- a/pkg/controller/static-resource-controller/controller.go
+++ b/pkg/controller/static-resource-controller/controller.go
@@ -136,6 +136,10 @@ func hasControllerManagedLabel(obj client.Object) bool {
 // Reconcile function to checks for the ZeroTrustWorkloadIdentityManager and creates the static resources required for
 // the operands to be used, and reflect the reconciliation status on the ZeroTrustWorkloadIdentityManager CR.
 func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if utils.IsReconciliationPaused() {
+		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+		return ctrl.Result{}, nil
+	}
 	var config v1alpha1.ZeroTrustWorkloadIdentityManager
 	err := r.ctrlClient.Get(ctx, req.NamespacedName, &config)
 	if err != nil {

--- a/pkg/controller/static-resource-controller/controller.go
+++ b/pkg/controller/static-resource-controller/controller.go
@@ -3,6 +3,7 @@ package static_resource_controller
 import (
 	"context"
 
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/featuregate"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -136,8 +137,8 @@ func hasControllerManagedLabel(obj client.Object) bool {
 // Reconcile function to checks for the ZeroTrustWorkloadIdentityManager and creates the static resources required for
 // the operands to be used, and reflect the reconciliation status on the ZeroTrustWorkloadIdentityManager CR.
 func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if utils.IsReconciliationPaused() {
-		r.log.Info("Reconciliation paused by environment flag", "env", utils.ReconciliationPausedEnv)
+	if utils.IsAutoReconcileDisabled() {
+		r.log.Info("Auto-reconciliation disabled to allow manual management", "feature", featuregate.DisableAutoReconcileFeature)
 		return ctrl.Result{}, nil
 	}
 	var config v1alpha1.ZeroTrustWorkloadIdentityManager

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -53,4 +53,7 @@ const (
 	SpiffeHelperImageEnv               = "RELATED_IMAGE_SPIFFE_HELPER"
 	NodeDriverRegistrarImageEnv        = "RELATED_IMAGE_NODE_DRIVER_REGISTRAR"
 	SpiffeCSIInitContainerImageEnv     = "RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER"
+
+	// Pause reconciliation flag
+	ReconciliationPausedEnv = "ZTWIM_PAUSE_RECONCILIATION"
 )

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -53,4 +53,9 @@ const (
 	SpiffeHelperImageEnv               = "RELATED_IMAGE_SPIFFE_HELPER"
 	NodeDriverRegistrarImageEnv        = "RELATED_IMAGE_NODE_DRIVER_REGISTRAR"
 	SpiffeCSIInitContainerImageEnv     = "RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER"
+
+	// Featuregate Status Conditions
+	FeatureGateStatusType          = "FeatureGateEnabled"
+	TechPreviewFeatureGateEnabled  = "TechPreviewFeatureGateEnabled"
+	TechPreviewFeatureGateDisabled = "TechPreviewFeatureGateDisabled"
 )

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -53,7 +53,4 @@ const (
 	SpiffeHelperImageEnv               = "RELATED_IMAGE_SPIFFE_HELPER"
 	NodeDriverRegistrarImageEnv        = "RELATED_IMAGE_NODE_DRIVER_REGISTRAR"
 	SpiffeCSIInitContainerImageEnv     = "RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER"
-
-	// Pause reconciliation flag
-	ReconciliationPausedEnv = "ZTWIM_PAUSE_RECONCILIATION"
 )

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -3,13 +3,12 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"os"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 
 	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/featuregate"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -140,17 +139,9 @@ func GenerateMapHash(m map[string]string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// IsReconciliationPaused returns true if the global pause env flag is set to a truthy value.
-func IsReconciliationPaused() bool {
-	val, ok := os.LookupEnv(ReconciliationPausedEnv)
-	if !ok {
-		return false
-	}
-	b, err := strconv.ParseBool(strings.TrimSpace(val))
-	if err != nil {
-		return false
-	}
-	return b
+// IsAutoReconcileDisabled returns true if the DISABLE_AUTO_RECONCILE feature gate is enabled.
+func IsAutoReconcileDisabled() bool {
+	return featuregate.IsAutoReconcileDisabled()
 }
 
 func StringToBool(s string) bool {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	securityv1 "github.com/openshift/api/security/v1"
@@ -136,6 +138,19 @@ func GenerateMapHash(m map[string]string) string {
 	// Compute the hash
 	hash := sha256.Sum256([]byte(builder.String()))
 	return hex.EncodeToString(hash[:])
+}
+
+// IsReconciliationPaused returns true if the global pause env flag is set to a truthy value.
+func IsReconciliationPaused() bool {
+	val, ok := os.LookupEnv(ReconciliationPausedEnv)
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(val))
+	if err != nil {
+		return false
+	}
+	return b
 }
 
 func StringToBool(s string) bool {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -16,6 +16,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/utils/pointer"
@@ -142,6 +143,16 @@ func GenerateMapHash(m map[string]string) string {
 // IsAutoReconcileDisabled returns true if the DISABLE_AUTO_RECONCILE feature gate is enabled.
 func IsAutoReconcileDisabled() bool {
 	return featuregate.IsAutoReconcileDisabled()
+}
+
+// HasCondition checks if a condition with the given type already exists in the conditions slice
+func HasCondition(conditions []metav1.Condition, conditionType string) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return true
+		}
+	}
+	return false
 }
 
 func StringToBool(s string) bool {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -14,6 +14,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestIsReconciliationPaused(t *testing.T) {
+	// Ensure clean state
+	os.Unsetenv(ReconciliationPausedEnv)
+
+	// default: not set -> false
+	if IsReconciliationPaused() {
+		t.Fatalf("expected false when %s not set", ReconciliationPausedEnv)
+	}
+
+	// truthy variants
+	for _, v := range []string{"true", "TRUE", "1"} {
+		os.Setenv(ReconciliationPausedEnv, v)
+		if !IsReconciliationPaused() {
+			t.Fatalf("expected true for value %q", v)
+		}
+	}
+
+	// falsy variants and invalid
+	for _, v := range []string{"false", "FALSE", "0", "", "not-a-bool"} {
+		os.Setenv(ReconciliationPausedEnv, v)
+		if v == "" {
+			os.Unsetenv(ReconciliationPausedEnv)
+		}
+		if IsReconciliationPaused() {
+			t.Fatalf("expected false for value %q", v)
+		}
+	}
+}
+
 // Helper function to set environment variable and return cleanup function
 func setEnvVar(key, value string) func() {
 	original := os.Getenv(key)

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -14,32 +14,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestIsReconciliationPaused(t *testing.T) {
-	// Ensure clean state
-	os.Unsetenv(ReconciliationPausedEnv)
+func TestIsAutoReconcileDisabled(t *testing.T) {
+	// Test that IsAutoReconcileDisabled delegates to featuregate.IsAutoReconcileDisabled()
+	// Since we can't easily mock the featuregate package here, we'll just test that
+	// the function returns false when no feature gates are configured
 
-	// default: not set -> false
-	if IsReconciliationPaused() {
-		t.Fatalf("expected false when %s not set", ReconciliationPausedEnv)
-	}
-
-	// truthy variants
-	for _, v := range []string{"true", "TRUE", "1"} {
-		os.Setenv(ReconciliationPausedEnv, v)
-		if !IsReconciliationPaused() {
-			t.Fatalf("expected true for value %q", v)
-		}
-	}
-
-	// falsy variants and invalid
-	for _, v := range []string{"false", "FALSE", "0", "", "not-a-bool"} {
-		os.Setenv(ReconciliationPausedEnv, v)
-		if v == "" {
-			os.Unsetenv(ReconciliationPausedEnv)
-		}
-		if IsReconciliationPaused() {
-			t.Fatalf("expected false for value %q", v)
-		}
+	// With no feature gates configured, should return false
+	if IsAutoReconcileDisabled() {
+		t.Fatal("expected false when no feature gates are configured")
 	}
 }
 

--- a/pkg/featuregate/constants.go
+++ b/pkg/featuregate/constants.go
@@ -1,0 +1,10 @@
+package featuregate
+
+const (
+	// UnsupportedAddonFeaturesEnv Environment variable for unsupported addon features
+	UnsupportedAddonFeaturesEnv = "UNSUPPORTED_ADDON_FEATURES"
+
+	// DisableAutoReconcileFeature Feature gates
+	DisableAutoReconcileFeature = "DISABLE_AUTO_RECONCILE"
+	// Add more feature gates here as needed
+)

--- a/pkg/featuregate/constants.go
+++ b/pkg/featuregate/constants.go
@@ -4,7 +4,7 @@ const (
 	// UnsupportedAddonFeaturesEnv Environment variable for unsupported addon features
 	UnsupportedAddonFeaturesEnv = "UNSUPPORTED_ADDON_FEATURES"
 
-	// DisableAutoReconcileFeature Feature gates
-	DisableAutoReconcileFeature = "DISABLE_AUTO_RECONCILE"
+	// TechPreviewFeature Feature gates
+	TechPreviewFeature = "TECH_PREVIEW"
 	// Add more feature gates here as needed
 )

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -1,0 +1,130 @@
+package featuregate
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Feature gate management
+var (
+	featureGates      = make(map[string]bool)
+	featureGatesMutex sync.RWMutex
+)
+
+// InitializeFeatureGates initializes the feature gates from the provided flags string
+// Format: "Feature1=true,Feature2=false"
+func InitializeFeatureGates(flagsStr string) error {
+	featureGatesMutex.Lock()
+	defer featureGatesMutex.Unlock()
+
+	// Clear existing gates
+	featureGates = make(map[string]bool)
+
+	if flagsStr == "" {
+		return nil
+	}
+
+	// Parse environment variable if present
+	if envVal := os.Getenv(UnsupportedAddonFeaturesEnv); envVal != "" {
+		// Environment variable takes precedence
+		flagsStr = envVal
+	}
+
+	features := strings.Split(flagsStr, ",")
+	for _, feature := range features {
+		feature = strings.TrimSpace(feature)
+		if feature == "" {
+			continue
+		}
+
+		parts := strings.SplitN(feature, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		featureName := strings.TrimSpace(parts[0])
+		featureValueStr := strings.TrimSpace(parts[1])
+
+		featureValue, err := strconv.ParseBool(featureValueStr)
+		if err != nil {
+			continue
+		}
+
+		featureGates[featureName] = featureValue
+	}
+
+	return nil
+}
+
+// IsFeatureGateEnabled checks if a specific feature gate is enabled
+func IsFeatureGateEnabled(featureName string) bool {
+	featureGatesMutex.RLock()
+	defer featureGatesMutex.RUnlock()
+
+	if enabled, exists := featureGates[featureName]; exists {
+		return enabled
+	}
+
+	return false
+}
+
+// GetFeatureGates returns a copy of all feature gates
+func GetFeatureGates() map[string]bool {
+	featureGatesMutex.RLock()
+	defer featureGatesMutex.RUnlock()
+
+	gates := make(map[string]bool, len(featureGates))
+	for k, v := range featureGates {
+		gates[k] = v
+	}
+
+	return gates
+}
+
+// IsAutoReconcileDisabled returns true if the DISABLE_AUTO_RECONCILE feature gate is enabled
+func IsAutoReconcileDisabled() bool {
+	return IsFeatureGateEnabled(DisableAutoReconcileFeature)
+}
+
+// GetEnabledFeatures returns a slice of all enabled feature gate names
+func GetEnabledFeatures() []string {
+	featureGatesMutex.RLock()
+	defer featureGatesMutex.RUnlock()
+
+	var enabled []string
+	for feature, isEnabled := range featureGates {
+		if isEnabled {
+			enabled = append(enabled, feature)
+		}
+	}
+	return enabled
+}
+
+// GetDisabledFeatures returns a slice of all explicitly disabled feature gate names
+func GetDisabledFeatures() []string {
+	featureGatesMutex.RLock()
+	defer featureGatesMutex.RUnlock()
+
+	var disabled []string
+	for feature, isEnabled := range featureGates {
+		if !isEnabled {
+			disabled = append(disabled, feature)
+		}
+	}
+	return disabled
+}
+
+// AreAnyFeaturesEnabled returns true if any feature gates are enabled
+func AreAnyFeaturesEnabled() bool {
+	featureGatesMutex.RLock()
+	defer featureGatesMutex.RUnlock()
+
+	for _, isEnabled := range featureGates {
+		if isEnabled {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -85,7 +85,7 @@ func GetFeatureGates() map[string]bool {
 
 // IsAutoReconcileDisabled returns true if the DISABLE_AUTO_RECONCILE feature gate is enabled
 func IsAutoReconcileDisabled() bool {
-	return IsFeatureGateEnabled(DisableAutoReconcileFeature)
+	return IsFeatureGateEnabled(TechPreviewFeature)
 }
 
 // GetEnabledFeatures returns a slice of all enabled feature gate names

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -1,0 +1,233 @@
+package featuregate
+
+import (
+	"os"
+	"testing"
+)
+
+func TestInitializeFeatureGates(t *testing.T) {
+	// Clean environment and state
+	os.Unsetenv(UnsupportedAddonFeaturesEnv)
+
+	tests := []struct {
+		name        string
+		flagsStr    string
+		envVal      string
+		expected    map[string]bool
+		expectError bool
+	}{
+		{
+			name:     "empty flags",
+			flagsStr: "",
+			expected: map[string]bool{},
+		},
+		{
+			name:     "single feature enabled",
+			flagsStr: "PauseReconciliation=true",
+			expected: map[string]bool{"PauseReconciliation": true},
+		},
+		{
+			name:     "single feature disabled",
+			flagsStr: "PauseReconciliation=false",
+			expected: map[string]bool{"PauseReconciliation": false},
+		},
+		{
+			name:     "multiple features",
+			flagsStr: "DISABLE_AUTO_RECONCILE=true,TEST_FEATURE_A=false,TEST_FEATURE_B=true",
+			expected: map[string]bool{"DISABLE_AUTO_RECONCILE": true, "TEST_FEATURE_A": false, "TEST_FEATURE_B": true},
+		},
+		{
+			name:     "whitespace handling",
+			flagsStr: " DISABLE_AUTO_RECONCILE = true , TEST_FEATURE_A = false ",
+			expected: map[string]bool{"DISABLE_AUTO_RECONCILE": true, "TEST_FEATURE_A": false},
+		},
+		{
+			name:     "env variable takes precedence",
+			flagsStr: "PauseReconciliation=false",
+			envVal:   "PauseReconciliation=true",
+			expected: map[string]bool{"PauseReconciliation": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment
+			if tt.envVal != "" {
+				os.Setenv(UnsupportedAddonFeaturesEnv, tt.envVal)
+				defer os.Unsetenv(UnsupportedAddonFeaturesEnv)
+			}
+
+			err := InitializeFeatureGates(tt.flagsStr)
+			if (err != nil) != tt.expectError {
+				t.Errorf("InitializeFeatureGates() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+
+			gates := GetFeatureGates()
+			if len(gates) != len(tt.expected) {
+				t.Errorf("Expected %d gates, got %d", len(tt.expected), len(gates))
+				return
+			}
+
+			for featureName, expectedValue := range tt.expected {
+				if actualValue, exists := gates[featureName]; !exists {
+					t.Errorf("Feature gate %s not found", featureName)
+				} else if actualValue != expectedValue {
+					t.Errorf("Feature gate %s = %v, expected %v", featureName, actualValue, expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestIsFeatureGateEnabled(t *testing.T) {
+	// Initialize with test data
+	err := InitializeFeatureGates("PauseReconciliation=true,TestFeature=false")
+	if err != nil {
+		t.Fatalf("Failed to initialize feature gates: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		feature  string
+		expected bool
+	}{
+		{
+			name:     "enabled feature",
+			feature:  "PauseReconciliation",
+			expected: true,
+		},
+		{
+			name:     "disabled feature",
+			feature:  "TestFeature",
+			expected: false,
+		},
+		{
+			name:     "non-existent feature",
+			feature:  "NonExistentFeature",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsFeatureGateEnabled(tt.feature)
+			if result != tt.expected {
+				t.Errorf("IsFeatureGateEnabled(%s) = %v, expected %v", tt.feature, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsAutoReconcileDisabled(t *testing.T) {
+	tests := []struct {
+		name             string
+		featureGateFlags string
+		expectedDisabled bool
+	}{
+		{
+			name:             "no feature gates",
+			expectedDisabled: false,
+		},
+		{
+			name:             "direct feature gate enabled",
+			featureGateFlags: "DISABLE_AUTO_RECONCILE=true",
+			expectedDisabled: true,
+		},
+		{
+			name:             "direct feature gate disabled",
+			featureGateFlags: "DISABLE_AUTO_RECONCILE=false",
+			expectedDisabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Initialize feature gates
+			err := InitializeFeatureGates(tt.featureGateFlags)
+			if err != nil {
+				t.Fatalf("Failed to initialize feature gates: %v", err)
+			}
+
+			result := IsAutoReconcileDisabled()
+			if result != tt.expectedDisabled {
+				t.Errorf("IsAutoReconcileDisabled() = %v, expected %v", result, tt.expectedDisabled)
+			}
+		})
+	}
+}
+
+func TestMultipleFeatureUtilities(t *testing.T) {
+	// Test GetEnabledFeatures, GetDisabledFeatures, and AreAnyFeaturesEnabled
+	err := InitializeFeatureGates("DISABLE_AUTO_RECONCILE=true,TEST_FEATURE_A=false,TEST_FEATURE_B=true")
+	if err != nil {
+		t.Fatalf("Failed to initialize feature gates: %v", err)
+	}
+
+	// Test GetEnabledFeatures
+	enabledFeatures := GetEnabledFeatures()
+	expectedEnabled := []string{"DISABLE_AUTO_RECONCILE", "TEST_FEATURE_B"}
+
+	if len(enabledFeatures) != len(expectedEnabled) {
+		t.Errorf("GetEnabledFeatures() returned %d features, expected %d", len(enabledFeatures), len(expectedEnabled))
+	}
+
+	for _, expected := range expectedEnabled {
+		found := false
+		for _, enabled := range enabledFeatures {
+			if enabled == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected feature %s to be in enabled features list", expected)
+		}
+	}
+
+	// Test GetDisabledFeatures
+	disabledFeatures := GetDisabledFeatures()
+	expectedDisabled := []string{"TEST_FEATURE_A"}
+
+	if len(disabledFeatures) != len(expectedDisabled) {
+		t.Errorf("GetDisabledFeatures() returned %d features, expected %d", len(disabledFeatures), len(expectedDisabled))
+	}
+
+	for _, expected := range expectedDisabled {
+		found := false
+		for _, disabled := range disabledFeatures {
+			if disabled == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected feature %s to be in disabled features list", expected)
+		}
+	}
+
+	// Test AreAnyFeaturesEnabled
+	if !AreAnyFeaturesEnabled() {
+		t.Error("AreAnyFeaturesEnabled() should return true when features are enabled")
+	}
+
+	// Test with no features enabled
+	err = InitializeFeatureGates("TEST_FEATURE_A=false,TEST_FEATURE_B=false")
+	if err != nil {
+		t.Fatalf("Failed to initialize feature gates: %v", err)
+	}
+
+	if AreAnyFeaturesEnabled() {
+		t.Error("AreAnyFeaturesEnabled() should return false when no features are enabled")
+	}
+
+	// Test with empty feature gates
+	err = InitializeFeatureGates("")
+	if err != nil {
+		t.Fatalf("Failed to initialize feature gates: %v", err)
+	}
+
+	if AreAnyFeaturesEnabled() {
+		t.Error("AreAnyFeaturesEnabled() should return false when no feature gates are set")
+	}
+}

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -131,12 +131,12 @@ func TestIsAutoReconcileDisabled(t *testing.T) {
 		},
 		{
 			name:             "direct feature gate enabled",
-			featureGateFlags: "DISABLE_AUTO_RECONCILE=true",
+			featureGateFlags: "TECH_PREVIEW=true",
 			expectedDisabled: true,
 		},
 		{
 			name:             "direct feature gate disabled",
-			featureGateFlags: "DISABLE_AUTO_RECONCILE=false",
+			featureGateFlags: "TECH_PREVIEW=false",
 			expectedDisabled: false,
 		},
 	}


### PR DESCRIPTION
Implements a feature gate mechanism to enable/disable experimental operator functionality through OLM subscription configuration.

### Key Changes
- **New Package**: `pkg/featuregate/` for feature gate management
- **DISABLE_AUTO_RECONCILE Feature**: Pauses reconciliation to allow manual resource management
- **Configuration**: Uses `UNSUPPORTED_ADDON_FEATURES` environment variable with `key=value` format
- **Integration**: Updated all controllers and manifests to support feature gates
- **Extensible**: Framework supports multiple feature gates simultaneously

### Usage
**Enable:**
```bash
oc patch subscription zero-trust-workload-identity-manager \
  --type='merge' \
  -p='{"spec":{"config":{"env":[{"name":"UNSUPPORTED_ADDON_FEATURES","value":"TECH_PREVIEW=true"}]}}}'
```

**Disable:**
```bash
oc patch subscription zero-trust-workload-identity-manager \
  --type='merge' \
  -p='{"spec":{"config":{"env":[{"name":"UNSUPPORTED_ADDON_FEATURES","value":"TECH_PREVIEW=false"}]}}}'
```