### PR TITLE
SPIRE-159: Adds support to enable and disable manual user configurations

### DIFF
--- a/pkg/controller/spiffe-csi-driver/controller.go
+++ b/pkg/controller/spiffe-csi-driver/controller.go
@@ -3,6 +3,7 @@ package spiffe_csi_driver
 import (
 	"context"
 	"fmt"
+
 	securityv1 "github.com/openshift/api/security/v1"
 	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -45,11 +46,12 @@ const (
 
 // SpiffeCsiReconciler reconciles a SpiffeCsi object
 type SpiffeCsiReconciler struct {
-	ctrlClient    customClient.CustomCtrlClient
-	ctx           context.Context
-	eventRecorder record.EventRecorder
-	log           logr.Logger
-	scheme        *runtime.Scheme
+	ctrlClient     customClient.CustomCtrlClient
+	ctx            context.Context
+	eventRecorder  record.EventRecorder
+	log            logr.Logger
+	scheme         *runtime.Scheme
+	createOnlyFlag bool
 }
 
 // New returns a new Reconciler instance.
@@ -59,11 +61,12 @@ func New(mgr ctrl.Manager) (*SpiffeCsiReconciler, error) {
 		return nil, err
 	}
 	return &SpiffeCsiReconciler{
-		ctrlClient:    c,
-		ctx:           context.Background(),
-		eventRecorder: mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName),
-		log:           ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName),
-		scheme:        mgr.GetScheme(),
+		ctrlClient:     c,
+		ctx:            context.Background(),
+		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName),
+		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName),
+		scheme:         mgr.GetScheme(),
+		createOnlyFlag: false,
 	}, nil
 }
 
@@ -75,6 +78,13 @@ func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	createOnlyMode := utils.IsInCreateOnlyMode(&spiffeCSIDriver, &r.createOnlyFlag)
+	if createOnlyMode {
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
+			"createOnlyAnnotation", utils.IsCreateOnlyMode(&spiffeCSIDriver),
+			"createOnlyFlag", r.createOnlyFlag)
 	}
 
 	reconcileStatus := map[string]reconcilerStatus{}
@@ -155,12 +165,16 @@ func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		r.log.Info("Created spiffe csi DaemonSet")
 	} else if err == nil && needsUpdate(existingSpiffeCsiDaemonSet, *spiffeCsiDaemonset) {
-		existingSpiffeCsiDaemonSet.Spec = spiffeCsiDaemonset.Spec
-		if err = r.ctrlClient.Update(ctx, &existingSpiffeCsiDaemonSet); err != nil {
-			r.log.Error(err, "failed to update spiffe csi daemon set")
-			return ctrl.Result{}, fmt.Errorf("failed to update DaemonSet: %w", err)
+		if createOnlyMode {
+			r.log.Info("Skipping DaemonSet update due to create-only mode")
+		} else {
+			existingSpiffeCsiDaemonSet.Spec = spiffeCsiDaemonset.Spec
+			if err = r.ctrlClient.Update(ctx, &existingSpiffeCsiDaemonSet); err != nil {
+				r.log.Error(err, "failed to update spiffe csi daemon set")
+				return ctrl.Result{}, fmt.Errorf("failed to update DaemonSet: %w", err)
+			}
+			r.log.Info("Updated spiffe csi DaemonSet")
 		}
-		r.log.Info("Updated spiffe csi DaemonSet")
 	} else if err != nil {
 		r.log.Error(err, "Failed to get SpiffeCsiDaemon set")
 		reconcileStatus[SpiffeCSIDaemonSetGeneration] = reconcilerStatus{

--- a/pkg/controller/spiffe-csi-driver/controller.go
+++ b/pkg/controller/spiffe-csi-driver/controller.go
@@ -51,7 +51,7 @@ type SpiffeCsiReconciler struct {
 	eventRecorder  record.EventRecorder
 	log            logr.Logger
 	scheme         *runtime.Scheme
-	createOnlyFlag bool
+	createOnlyMode bool
 }
 
 // New returns a new Reconciler instance.
@@ -66,7 +66,7 @@ func New(mgr ctrl.Manager) (*SpiffeCsiReconciler, error) {
 		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName),
 		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName),
 		scheme:         mgr.GetScheme(),
-		createOnlyFlag: false,
+		createOnlyMode: false,
 	}, nil
 }
 
@@ -106,7 +106,7 @@ func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}(reconcileStatus)
 
-	createOnlyMode := utils.IsInCreateOnlyMode(&spiffeCSIDriver, &r.createOnlyFlag)
+	createOnlyMode := utils.IsInCreateOnlyMode(&spiffeCSIDriver, &r.createOnlyMode)
 	if createOnlyMode {
 		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 		reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
@@ -120,7 +120,7 @@ func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
 				Status:  metav1.ConditionFalse,
 				Reason:  utils.CreateOnlyModeDisabled,
-				Message: "Create-only mode is disabled - annotation not present or set to false",
+				Message: "Create-only mode is disabled",
 			}
 		}
 	}

--- a/pkg/controller/spiffe-csi-driver/controller.go
+++ b/pkg/controller/spiffe-csi-driver/controller.go
@@ -82,9 +82,7 @@ func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	createOnlyMode := utils.IsInCreateOnlyMode(&spiffeCSIDriver, &r.createOnlyFlag)
 	if createOnlyMode {
-		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
-			"createOnlyAnnotation", utils.IsCreateOnlyMode(&spiffeCSIDriver),
-			"createOnlyFlag", r.createOnlyFlag)
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 	}
 
 	reconcileStatus := map[string]reconcilerStatus{}

--- a/pkg/controller/spire-agent/controller.go
+++ b/pkg/controller/spire-agent/controller.go
@@ -55,7 +55,7 @@ type SpireAgentReconciler struct {
 	eventRecorder  record.EventRecorder
 	log            logr.Logger
 	scheme         *runtime.Scheme
-	createOnlyFlag bool
+	createOnlyMode bool
 }
 
 // New returns a new Reconciler instance.
@@ -70,7 +70,7 @@ func New(mgr ctrl.Manager) (*SpireAgentReconciler, error) {
 		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpireAgentControllerName),
 		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpireAgentControllerName),
 		scheme:         mgr.GetScheme(),
-		createOnlyFlag: false,
+		createOnlyMode: false,
 	}, nil
 }
 
@@ -110,7 +110,7 @@ func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}(reconcileStatus)
 
-	createOnlyMode := utils.IsInCreateOnlyMode(&agent, &r.createOnlyFlag)
+	createOnlyMode := utils.IsInCreateOnlyMode(&agent, &r.createOnlyMode)
 	if createOnlyMode {
 		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 		reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
@@ -124,7 +124,7 @@ func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
 				Status:  metav1.ConditionFalse,
 				Reason:  utils.CreateOnlyModeDisabled,
-				Message: "Create-only mode is disabled - annotation not present or set to false",
+				Message: "Create-only mode is disabled",
 			}
 		}
 	}

--- a/pkg/controller/spire-agent/controller.go
+++ b/pkg/controller/spire-agent/controller.go
@@ -86,9 +86,7 @@ func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	createOnlyMode := utils.IsInCreateOnlyMode(&agent, &r.createOnlyFlag)
 	if createOnlyMode {
-		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
-			"createOnlyAnnotation", utils.IsCreateOnlyMode(&agent),
-			"createOnlyFlag", r.createOnlyFlag)
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 	}
 
 	reconcileStatus := map[string]reconcilerStatus{}

--- a/pkg/controller/spire-oidc-discovery-provider/controller.go
+++ b/pkg/controller/spire-oidc-discovery-provider/controller.go
@@ -52,7 +52,7 @@ type SpireOidcDiscoveryProviderReconciler struct {
 	eventRecorder  record.EventRecorder
 	log            logr.Logger
 	scheme         *runtime.Scheme
-	createOnlyFlag bool
+	createOnlyMode bool
 }
 
 // New returns a new Reconciler instance.
@@ -67,7 +67,7 @@ func New(mgr ctrl.Manager) (*SpireOidcDiscoveryProviderReconciler, error) {
 		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpireOIDCDiscoveryProviderControllerName),
 		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpireOIDCDiscoveryProviderControllerName),
 		scheme:         mgr.GetScheme(),
-		createOnlyFlag: false,
+		createOnlyMode: false,
 	}, nil
 }
 
@@ -108,7 +108,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, re
 		}
 	}(reconcileStatus)
 
-	createOnlyMode := utils.IsInCreateOnlyMode(&oidcDiscoveryProviderConfig, &r.createOnlyFlag)
+	createOnlyMode := utils.IsInCreateOnlyMode(&oidcDiscoveryProviderConfig, &r.createOnlyMode)
 	if createOnlyMode {
 		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 		reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
@@ -122,7 +122,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, re
 			reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
 				Status:  metav1.ConditionFalse,
 				Reason:  utils.CreateOnlyModeDisabled,
-				Message: "Create-only mode is disabled - annotation not present or set to false",
+				Message: "Create-only mode is disabled",
 			}
 		}
 	}

--- a/pkg/controller/spire-oidc-discovery-provider/controller.go
+++ b/pkg/controller/spire-oidc-discovery-provider/controller.go
@@ -85,9 +85,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, re
 
 	createOnlyMode := utils.IsInCreateOnlyMode(&oidcDiscoveryProviderConfig, &r.createOnlyFlag)
 	if createOnlyMode {
-		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
-			"createOnlyAnnotation", utils.IsCreateOnlyMode(&oidcDiscoveryProviderConfig),
-			"createOnlyFlag", r.createOnlyFlag)
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 	}
 	reconcileStatus := map[string]reconcilerStatus{}
 	defer func(reconcileStatus map[string]reconcilerStatus) {

--- a/pkg/controller/spire-server/controller.go
+++ b/pkg/controller/spire-server/controller.go
@@ -88,9 +88,7 @@ func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	createOnlyMode := utils.IsInCreateOnlyMode(&server, &r.createOnlyFlag)
 	if createOnlyMode {
-		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
-			"createOnlyAnnotation", utils.IsCreateOnlyMode(&server),
-			"createOnlyFlag", r.createOnlyFlag)
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 	}
 	reconcileStatus := map[string]reconcilerStatus{}
 	defer func(reconcileStatus map[string]reconcilerStatus) {

--- a/pkg/controller/spire-server/controller.go
+++ b/pkg/controller/spire-server/controller.go
@@ -54,7 +54,7 @@ type SpireServerReconciler struct {
 	eventRecorder  record.EventRecorder
 	log            logr.Logger
 	scheme         *runtime.Scheme
-	createOnlyFlag bool
+	createOnlyMode bool
 }
 
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
@@ -72,7 +72,7 @@ func New(mgr ctrl.Manager) (*SpireServerReconciler, error) {
 		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpireServerControllerName),
 		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpireServerControllerName),
 		scheme:         mgr.GetScheme(),
-		createOnlyFlag: false,
+		createOnlyMode: false,
 	}, nil
 }
 
@@ -112,7 +112,7 @@ func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}(reconcileStatus)
 
-	createOnlyMode := utils.IsInCreateOnlyMode(&server, &r.createOnlyFlag)
+	createOnlyMode := utils.IsInCreateOnlyMode(&server, &r.createOnlyMode)
 	if createOnlyMode {
 		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 		reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
@@ -126,7 +126,7 @@ func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
 				Status:  metav1.ConditionFalse,
 				Reason:  utils.CreateOnlyModeDisabled,
-				Message: "Create-only mode is disabled - annotation not present or set to false",
+				Message: "Create-only mode is disabled",
 			}
 		}
 	}

--- a/pkg/controller/static-resource-controller/controller.go
+++ b/pkg/controller/static-resource-controller/controller.go
@@ -163,9 +163,7 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	createOnlyMode := utils.IsInCreateOnlyMode(&config, &r.createOnlyFlag)
 	if createOnlyMode {
-		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
-			"createOnlyAnnotation", utils.IsCreateOnlyMode(&config),
-			"createOnlyFlag", r.createOnlyFlag)
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 	}
 	reconcileStatus := map[string]reconcilerStatus{}
 	defer func(reconcileStatus map[string]reconcilerStatus) {

--- a/pkg/controller/static-resource-controller/controller.go
+++ b/pkg/controller/static-resource-controller/controller.go
@@ -46,7 +46,7 @@ type StaticResourceReconciler struct {
 	eventRecorder  record.EventRecorder
 	log            logr.Logger
 	scheme         *runtime.Scheme
-	createOnlyFlag bool
+	createOnlyMode bool
 }
 
 type reconcilerStatus struct {
@@ -113,7 +113,7 @@ func New(mgr ctrl.Manager) (*StaticResourceReconciler, error) {
 		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerStaticResourceControllerName),
 		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerStaticResourceControllerName),
 		scheme:         mgr.GetScheme(),
-		createOnlyFlag: false,
+		createOnlyMode: false,
 	}, nil
 }
 
@@ -187,7 +187,7 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}(reconcileStatus)
 
-	createOnlyMode := utils.IsInCreateOnlyMode(&config, &r.createOnlyFlag)
+	createOnlyMode := utils.IsInCreateOnlyMode(&config, &r.createOnlyMode)
 	if createOnlyMode {
 		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates")
 		reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
@@ -201,7 +201,7 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			reconcileStatus[utils.CreateOnlyModeStatusType] = reconcilerStatus{
 				Status:  metav1.ConditionFalse,
 				Reason:  utils.CreateOnlyModeDisabled,
-				Message: "Create-only mode is disabled - annotation not present or set to false",
+				Message: "Create-only mode is disabled",
 			}
 		}
 	}

--- a/pkg/controller/static-resource-controller/controller.go
+++ b/pkg/controller/static-resource-controller/controller.go
@@ -41,11 +41,12 @@ const (
 )
 
 type StaticResourceReconciler struct {
-	ctrlClient    customClient.CustomCtrlClient
-	ctx           context.Context
-	eventRecorder record.EventRecorder
-	log           logr.Logger
-	scheme        *runtime.Scheme
+	ctrlClient     customClient.CustomCtrlClient
+	ctx            context.Context
+	eventRecorder  record.EventRecorder
+	log            logr.Logger
+	scheme         *runtime.Scheme
+	createOnlyFlag bool
 }
 
 type reconcilerStatus struct {
@@ -107,11 +108,12 @@ func New(mgr ctrl.Manager) (*StaticResourceReconciler, error) {
 		return nil, err
 	}
 	return &StaticResourceReconciler{
-		ctrlClient:    c,
-		ctx:           context.Background(),
-		eventRecorder: mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerStaticResourceControllerName),
-		log:           ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerStaticResourceControllerName),
-		scheme:        mgr.GetScheme(),
+		ctrlClient:     c,
+		ctx:            context.Background(),
+		eventRecorder:  mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerStaticResourceControllerName),
+		log:            ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerStaticResourceControllerName),
+		scheme:         mgr.GetScheme(),
+		createOnlyFlag: false,
 	}, nil
 }
 
@@ -158,6 +160,13 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		return ctrl.Result{}, err
 	}
+
+	createOnlyMode := utils.IsInCreateOnlyMode(&config, &r.createOnlyFlag)
+	if createOnlyMode {
+		r.log.Info("Running in create-only mode - will create resources if they don't exist but skip updates",
+			"createOnlyAnnotation", utils.IsCreateOnlyMode(&config),
+			"createOnlyFlag", r.createOnlyFlag)
+	}
 	reconcileStatus := map[string]reconcilerStatus{}
 	defer func(reconcileStatus map[string]reconcilerStatus) {
 		originalStatus := config.Status.DeepCopy()
@@ -183,7 +192,7 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 		}
 	}(reconcileStatus)
-	err = r.CreateOrApplyRbacResources(ctx)
+	err = r.CreateOrApplyRbacResources(ctx, createOnlyMode)
 	if err != nil {
 		r.log.Error(err, "failed to create or apply rbac resources")
 		r.eventRecorder.Event(&config, corev1.EventTypeWarning, "failed to create RBAC resources",
@@ -200,7 +209,7 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		Reason:  "RBACResourceCreated",
 		Message: "All RBAC resources for operands created",
 	}
-	err = r.CreateOrApplyServiceAccountResources(ctx)
+	err = r.CreateOrApplyServiceAccountResources(ctx, createOnlyMode)
 	if err != nil {
 		r.log.Error(err, "failed to create or apply service accounts resources")
 		r.eventRecorder.Event(&config, corev1.EventTypeWarning, "failed to create Service Account resources",
@@ -217,7 +226,7 @@ func (r *StaticResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		Reason:  "ServiceAccountResourceCreated",
 		Message: "Service Account resources for operands are created",
 	}
-	err = r.CreateOrApplyServiceResources(ctx)
+	err = r.CreateOrApplyServiceResources(ctx, createOnlyMode)
 	if err != nil {
 		r.log.Error(err, "failed to create or apply services resources")
 		r.eventRecorder.Event(&config, corev1.EventTypeWarning, "failed to create Service resources",

--- a/pkg/controller/static-resource-controller/csi.go
+++ b/pkg/controller/static-resource-controller/csi.go
@@ -2,6 +2,7 @@ package static_resource_controller
 
 import (
 	"context"
+
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 

--- a/pkg/controller/static-resource-controller/service-account.go
+++ b/pkg/controller/static-resource-controller/service-account.go
@@ -8,11 +8,10 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/operator/assets"
 )
 
-func (r *StaticResourceReconciler) CreateOrApplyServiceAccountResources(ctx context.Context) error {
+func (r *StaticResourceReconciler) CreateOrApplyServiceAccountResources(ctx context.Context, createOnlyMode bool) error {
 	for _, serviceAccount := range r.listStaticServiceAccount() {
-		err := r.ctrlClient.CreateOrUpdateObject(ctx, serviceAccount)
+		err := r.createOrUpdateResource(ctx, serviceAccount, createOnlyMode, "ServiceAccount")
 		if err != nil {
-			r.log.Error(err, "unable to create or update Service resource")
 			return err
 		}
 	}

--- a/pkg/controller/static-resource-controller/service.go
+++ b/pkg/controller/static-resource-controller/service.go
@@ -8,11 +8,10 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/operator/assets"
 )
 
-func (r *StaticResourceReconciler) CreateOrApplyServiceResources(ctx context.Context) error {
+func (r *StaticResourceReconciler) CreateOrApplyServiceResources(ctx context.Context, createOnlyMode bool) error {
 	for _, service := range r.listStaticServiceResource() {
-		err := r.ctrlClient.CreateOrUpdateObject(ctx, service)
+		err := r.createOrUpdateResource(ctx, service, createOnlyMode, "Service")
 		if err != nil {
-			r.log.Error(err, "unable to create or update Service resource")
 			return err
 		}
 	}

--- a/pkg/controller/utils/annotations.go
+++ b/pkg/controller/utils/annotations.go
@@ -5,7 +5,10 @@ import (
 )
 
 const (
-	CreateOnlyAnnotation = "ztwim.openshift.io/create-only"
+	CreateOnlyAnnotation     = "ztwim.openshift.io/create-only"
+	CreateOnlyModeStatusType = "CreateOnlyMode"
+	CreateOnlyModeEnabled    = "CreateOnlyModeEnabled"
+	CreateOnlyModeDisabled   = "CreateOnlyModeDisabled"
 )
 
 func IsCreateOnlyAnnotationEnabled(obj client.Object) bool {

--- a/pkg/controller/utils/annotations.go
+++ b/pkg/controller/utils/annotations.go
@@ -8,7 +8,7 @@ const (
 	CreateOnlyAnnotation = "ztwim.openshift.io/create-only"
 )
 
-func IsCreateOnlyMode(obj client.Object) bool {
+func IsCreateOnlyAnnotationEnabled(obj client.Object) bool {
 	if obj == nil {
 		return false
 	}
@@ -20,7 +20,7 @@ func IsCreateOnlyMode(obj client.Object) bool {
 }
 
 func IsInCreateOnlyMode(obj client.Object, createOnlyFlag *bool) bool {
-	currentCreateOnly := IsCreateOnlyMode(obj)
+	currentCreateOnly := IsCreateOnlyAnnotationEnabled(obj)
 	if currentCreateOnly {
 		*createOnlyFlag = true
 		return true

--- a/pkg/controller/utils/annotations.go
+++ b/pkg/controller/utils/annotations.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CreateOnlyAnnotation = "ztwim.openshift.io/create-only"
+)
+
+func IsCreateOnlyMode(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	return annotations[CreateOnlyAnnotation] == "true"
+}
+
+func IsInCreateOnlyMode(obj client.Object, createOnlyFlag *bool) bool {
+	currentCreateOnly := IsCreateOnlyMode(obj)
+	if currentCreateOnly {
+		*createOnlyFlag = true
+		return true
+	}
+	if *createOnlyFlag {
+		return true
+	}
+	return false
+}

--- a/pkg/controller/utils/annotations_test.go
+++ b/pkg/controller/utils/annotations_test.go
@@ -132,9 +132,9 @@ func TestIsCreateOnlyMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsCreateOnlyMode(tt.obj)
+			result := IsCreateOnlyAnnotationEnabled(tt.obj)
 			if result != tt.expected {
-				t.Errorf("IsCreateOnlyMode() = %v, expected %v - %s", result, tt.expected, tt.description)
+				t.Errorf("IsCreateOnlyAnnotationEnabled() = %v, expected %v - %s", result, tt.expected, tt.description)
 			}
 		})
 	}

--- a/pkg/controller/utils/annotations_test.go
+++ b/pkg/controller/utils/annotations_test.go
@@ -1,0 +1,340 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestIsCreateOnlyMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         client.Object
+		expected    bool
+		description string
+	}{
+		{
+			name:        "nil object",
+			obj:         nil,
+			expected:    false,
+			description: "should return false when object is nil",
+		},
+		{
+			name: "object with nil annotations",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			expected:    false,
+			description: "should return false when annotations map is nil",
+		},
+		{
+			name: "object with empty annotations",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected:    false,
+			description: "should return false when annotations map is empty",
+		},
+		{
+			name: "object with create-only annotation set to true",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "true",
+					},
+				},
+			},
+			expected:    true,
+			description: "should return true when create-only annotation is set to 'true'",
+		},
+		{
+			name: "object with create-only annotation set to false",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "false",
+					},
+				},
+			},
+			expected:    false,
+			description: "should return false when create-only annotation is set to 'false'",
+		},
+		{
+			name: "object with create-only annotation set to empty string",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "",
+					},
+				},
+			},
+			expected:    false,
+			description: "should return false when create-only annotation is empty string",
+		},
+		{
+			name: "object with create-only annotation set to invalid value",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "invalid",
+					},
+				},
+			},
+			expected:    false,
+			description: "should return false when create-only annotation has invalid value",
+		},
+		{
+			name: "object with other annotations but no create-only",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other.annotation": "value",
+						"another.one":      "true",
+					},
+				},
+			},
+			expected:    false,
+			description: "should return false when create-only annotation is not present",
+		},
+		{
+			name: "object with create-only annotation and other annotations",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "true",
+						"other.annotation":   "value",
+					},
+				},
+			},
+			expected:    true,
+			description: "should return true when create-only annotation is 'true' even with other annotations",
+		},
+		{
+			name: "SpireServer object with create-only annotation",
+			obj: &v1alpha1.SpireServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "true",
+					},
+				},
+			},
+			expected:    true,
+			description: "should return true for SpireServer with create-only annotation set to 'true'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsCreateOnlyMode(tt.obj)
+			if result != tt.expected {
+				t.Errorf("IsCreateOnlyMode() = %v, expected %v - %s", result, tt.expected, tt.description)
+			}
+		})
+	}
+}
+
+func TestIsInCreateOnlyMode(t *testing.T) {
+	tests := []struct {
+		name              string
+		obj               client.Object
+		createOnlyFlag    bool
+		expectedResult    bool
+		expectedFlagAfter bool
+		description       string
+	}{
+		{
+			name:              "nil object with flag false",
+			obj:               nil,
+			createOnlyFlag:    false,
+			expectedResult:    false,
+			expectedFlagAfter: false,
+			description:       "should return false when object is nil and flag is false",
+		},
+		{
+			name:              "nil object with flag true",
+			obj:               nil,
+			createOnlyFlag:    true,
+			expectedResult:    true,
+			expectedFlagAfter: true,
+			description:       "should return true when object is nil but flag is true",
+		},
+		{
+			name: "object without annotation, flag false",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			createOnlyFlag:    false,
+			expectedResult:    false,
+			expectedFlagAfter: false,
+			description:       "should return false when object has no annotation and flag is false",
+		},
+		{
+			name: "object without annotation, flag true",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			createOnlyFlag:    true,
+			expectedResult:    true,
+			expectedFlagAfter: true,
+			description:       "should return true when object has no annotation but flag is true",
+		},
+		{
+			name: "object with annotation true, flag false",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "true",
+					},
+				},
+			},
+			createOnlyFlag:    false,
+			expectedResult:    true,
+			expectedFlagAfter: true,
+			description:       "should return true and set flag to true when object has annotation set to true",
+		},
+		{
+			name: "object with annotation true, flag true",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "true",
+					},
+				},
+			},
+			createOnlyFlag:    true,
+			expectedResult:    true,
+			expectedFlagAfter: true,
+			description:       "should return true and keep flag true when both object annotation and flag are true",
+		},
+		{
+			name: "object with annotation false, flag false",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "false",
+					},
+				},
+			},
+			createOnlyFlag:    false,
+			expectedResult:    false,
+			expectedFlagAfter: false,
+			description:       "should return false when both object annotation and flag are false",
+		},
+		{
+			name: "object with annotation false, flag true",
+			obj: &v1alpha1.ZeroTrustWorkloadIdentityManager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "false",
+					},
+				},
+			},
+			createOnlyFlag:    true,
+			expectedResult:    true,
+			expectedFlagAfter: true,
+			description:       "should return true when object annotation is false but flag is true",
+		},
+		{
+			name: "SpireServer object with annotation true, flag false",
+			obj: &v1alpha1.SpireServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CreateOnlyAnnotation: "true",
+					},
+				},
+			},
+			createOnlyFlag:    false,
+			expectedResult:    true,
+			expectedFlagAfter: true,
+			description:       "should return true and set flag to true for SpireServer with annotation set to true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copy of the flag since it's passed by reference
+			flagCopy := tt.createOnlyFlag
+			result := IsInCreateOnlyMode(tt.obj, &flagCopy)
+
+			if result != tt.expectedResult {
+				t.Errorf("IsInCreateOnlyMode() = %v, expected %v - %s", result, tt.expectedResult, tt.description)
+			}
+
+			if flagCopy != tt.expectedFlagAfter {
+				t.Errorf("createOnlyFlag after call = %v, expected %v - %s", flagCopy, tt.expectedFlagAfter, tt.description)
+			}
+		})
+	}
+}
+
+func TestIsInCreateOnlyMode_WithUnstructuredObject(t *testing.T) {
+	// Test with a real Kubernetes object type to ensure compatibility
+	obj := &unstructured.Unstructured{}
+	obj.SetAnnotations(map[string]string{
+		CreateOnlyAnnotation: "true",
+	})
+
+	flag := false
+	result := IsInCreateOnlyMode(obj, &flag)
+
+	if !result {
+		t.Errorf("IsInCreateOnlyMode() with unstructured object = %v, expected true", result)
+	}
+
+	if !flag {
+		t.Errorf("createOnlyFlag after call with unstructured object = %v, expected true", flag)
+	}
+}
+
+func TestIsInCreateOnlyMode_WithDifferentAPITypes(t *testing.T) {
+	// Test with SpireAgent
+	spireAgent := &v1alpha1.SpireAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				CreateOnlyAnnotation: "true",
+			},
+		},
+	}
+
+	flag := false
+	result := IsInCreateOnlyMode(spireAgent, &flag)
+
+	if !result {
+		t.Errorf("IsInCreateOnlyMode() with SpireAgent = %v, expected true", result)
+	}
+
+	if !flag {
+		t.Errorf("createOnlyFlag after call with SpireAgent = %v, expected true", flag)
+	}
+
+	// Test with SpireOIDCDiscoveryProvider
+	spireOIDC := &v1alpha1.SpireOIDCDiscoveryProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				CreateOnlyAnnotation: "false",
+			},
+		},
+	}
+
+	flag2 := true
+	result2 := IsInCreateOnlyMode(spireOIDC, &flag2)
+
+	if !result2 {
+		t.Errorf("IsInCreateOnlyMode() with SpireOIDCDiscoveryProvider = %v, expected true", result2)
+	}
+
+	if !flag2 {
+		t.Errorf("createOnlyFlag after call with SpireOIDCDiscoveryProvider = %v, expected true", flag2)
+	}
+}


### PR DESCRIPTION
## Add create-only annotation support

Implements `ztwim.openshift.io/create-only=true` annotation to skip Day 2 operations (updates) while allowing resource creation.

**Changes:**
- Added annotation support to all ZTWIM controllers
- In-memory flag persists the create-only state until pod restart

**Usage:**
```yaml
metadata:
  annotations:
    ztwim.openshift.io/create-only: "true"
```