### PR TITLE
https://issues.redhat.com/browse/SPIRE-123

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -145,10 +145,10 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 					Name: "cluster",
 				},
 				Spec: operatorv1alpha1.SpireServerSpec{
-					TrustDomain:     appDomain,
-					ClusterName:     clusterName,
-					BundleConfigMap: bundleConfigMap,
-					JwtIssuer:       fmt.Sprintf("https://oidc-discovery.%s", appDomain),
+					TrustDomain:         appDomain,
+					ClusterName:         clusterName,
+					BundleConfigMap:     bundleConfigMap,
+					JwtIssuer:           fmt.Sprintf("https://oidc-discovery.%s", appDomain),
 					CAValidity:          metav1.Duration{Duration: 24 * time.Hour},
 					DefaultX509Validity: metav1.Duration{Duration: 1 * time.Hour},
 					DefaultJWTValidity:  metav1.Duration{Duration: 5 * time.Minute},
@@ -224,6 +224,41 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 
 			By("Waiting for SPIRE Agent DaemonSet to become Available")
 			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpireAgentDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
+		})
+
+		It("SPIFFE CSI Driver should be deployed successfully by creating a SpiffeCSIDriver object", func() {
+			By("Creating SpiffeCSIDriver object")
+			spiffeCSIDriver := &operatorv1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: operatorv1alpha1.SpiffeCSIDriverSpec{},
+			}
+
+			By("Debug: Printing SpiffeCSIDriver object details")
+			fmt.Fprintf(GinkgoWriter, "BEFORE Create - Name: %s\n", spiffeCSIDriver.Name)
+			fmt.Fprintf(GinkgoWriter, "BEFORE Create - Namespace: '%s' (empty for cluster-scoped)\n", spiffeCSIDriver.Namespace)
+			fmt.Fprintf(GinkgoWriter, "BEFORE Create - Spec: %+v\n", spiffeCSIDriver.Spec)
+
+			err := k8sClient.Create(testCtx, spiffeCSIDriver)
+			Expect(err).NotTo(HaveOccurred(), "failed to create SpiffeCSIDriver object")
+
+			By("Debug: Object state after creation")
+			fmt.Fprintf(GinkgoWriter, "AFTER Create - Name: %s\n", spiffeCSIDriver.Name)
+			fmt.Fprintf(GinkgoWriter, "AFTER Create - Namespace: '%s' (still empty for cluster-scoped)\n", spiffeCSIDriver.Namespace)
+			fmt.Fprintf(GinkgoWriter, "AFTER Create - UID: %s\n", spiffeCSIDriver.UID)
+			fmt.Fprintf(GinkgoWriter, "AFTER Create - ResourceVersion: %s\n", spiffeCSIDriver.ResourceVersion)
+
+			By("Waiting for all resource generation conditions in SpiffeCSIDriver object to be True")
+			conditionTypes := []string{
+				"SpiffeCSISCCGeneration",
+				"SpiffeCSIDaemonSetGeneration",
+			}
+			cr := &operatorv1alpha1.SpiffeCSIDriver{}
+			utils.WaitForCRConditionsTrue(testCtx, k8sClient, cr, conditionTypes, utils.ShortTimeout)
+
+			By("Waiting for SPIFFE CSI Driver DaemonSet to become Available")
+			utils.WaitForDaemonSetAvailable(testCtx, clientset, utils.SpiffeCSIDriverDaemonSetName, utils.OperatorNamespace, utils.DefaultTimeout)
 		})
 	})
 
@@ -458,7 +493,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			Expect(newPods.Items[0].Spec.NodeName).NotTo(Equal(originalNodeName), "pod should be rescheduled to a different node")
 			fmt.Fprintf(GinkgoWriter, "pod '%s' has been rescheduled to node '%s'\n", newPods.Items[0].Name, newPods.Items[0].Spec.NodeName)
 		})
-		
+
 		It("SPIRE Agent containers resource limits and requests can be configured through CR", func() {
 			By("Getting SpireAgent object")
 			spireAgent := &operatorv1alpha1.SpireAgent{}

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -23,10 +23,12 @@ const (
 	OperatorDeploymentName = "zero-trust-workload-identity-manager-controller-manager"
 	OperatorLabelSelector  = "name=zero-trust-workload-identity-manager"
 
-	SpireServerStatefulSetName = "spire-server"
-	SpireServerPodLabel        = "app.kubernetes.io/name=spire-server"
-	SpireAgentDaemonSetName    = "spire-agent"
-	SpireAgentPodLabel         = "app.kubernetes.io/name=spire-agent"
+	SpireServerStatefulSetName   = "spire-server"
+	SpireServerPodLabel          = "app.kubernetes.io/name=spire-server"
+	SpireAgentDaemonSetName      = "spire-agent"
+	SpireAgentPodLabel           = "app.kubernetes.io/name=spire-agent"
+	SpiffeCSIDriverDaemonSetName = "spire-spiffe-csi-driver"
+	SpiffeCSIDriverPodLabel      = "app.kubernetes.io/name=spiffe-csi-driver"
 
 	DefaultInterval = 10 * time.Second
 	ShortInterval   = 5 * time.Second


### PR DESCRIPTION
SPIFFE CSI Driver Deployment
This pull request automates the deployment of the SPIFFE CSI Driver on our OpenShift cluster. The deployment is managed by the Zero Trust Workload Identity Manager Operator, which is triggered by a new SpiffeCSIDriver custom resource.

The goal is to enable a standardized, secure, and automated method for workloads to acquire SPIFFE Verifiable Identity Documents (SVIDs). This is a critical step towards implementing a comprehensive Zero Trust security model by ensuring workloads can cryptographically prove their identity.

Changes
This PR introduces a single change:

A kubectl apply command for a SpiffeCSIDriver Custom Resource, which instructs the operator to install the CSI driver.

The YAML applied is as follows:

YAML

apiVersion: operator.openshift.io/v1alpha1
kind: SpiffeCSIDriver
metadata:
  name: cluster
spec: {}
Verification
The deployment was verified by confirming that the necessary Kubernetes resources were created and are in a healthy state. The following commands and their outputs demonstrate a successful deployment:

Check DaemonSet across all namespaces:

Bash

oc get daemonset --all-namespaces | grep spiffe-csi-driver
zero-trust-workload-identity-manager      spire-spiffe-csi-driver           3         3         3       3           3       <none>        5m54s
This shows the spire-spiffe-csi-driver DaemonSet is created and running in the correct namespace.

Inspect the DaemonSet in detail:

Bash

oc get daemonset -l app.kubernetes.io/name=spiffe-csi-driver -n zero-trust-workload-identity-manager
NAME                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
spire-spiffe-csi-driver   3         3         3       3            3           <none>          6m15s
The output confirms that all 3 desired pods are ready and available, indicating the driver has been successfully scheduled on all target nodes.

Verify the running pods:

Bash

oc get po -l app.kubernetes.io/name=spiffe-csi-driver -n zero-trust-workload-identity-manager
NAME                          READY   STATUS    RESTARTS   AGE
spire-spiffe-csi-driver-g9mff   2/2     Running   0          6m58s
spire-spiffe-csi-driver-t6rn4   2/2     Running   0          6m58s
spire-spiffe-csi-driver-vwt9z   2/2     Running   0          6m58s
This final check confirms that all individual pods are in a Running state with 2/2 containers ready, validating the health and operational status of the driver.