### PR TITLE
SPIRE-179: Add e2e test for spiffe oidc discovery provider installation

### DIFF
--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -23,12 +23,14 @@ const (
 	OperatorDeploymentName = "zero-trust-workload-identity-manager-controller-manager"
 	OperatorLabelSelector  = "name=zero-trust-workload-identity-manager"
 
-	SpireServerStatefulSetName   = "spire-server"
-	SpireServerPodLabel          = "app.kubernetes.io/name=spire-server"
-	SpireAgentDaemonSetName      = "spire-agent"
-	SpireAgentPodLabel           = "app.kubernetes.io/name=spire-agent"
-	SpiffeCSIDriverDaemonSetName = "spire-spiffe-csi-driver"
-	SpiffeCSIDriverPodLabel      = "app.kubernetes.io/name=spiffe-csi-driver"
+	SpireServerStatefulSetName               = "spire-server"
+	SpireServerPodLabel                      = "app.kubernetes.io/name=spire-server"
+	SpireAgentDaemonSetName                  = "spire-agent"
+	SpireAgentPodLabel                       = "app.kubernetes.io/name=spire-agent"
+	SpiffeCSIDriverDaemonSetName             = "spire-spiffe-csi-driver"
+	SpiffeCSIDriverPodLabel                  = "app.kubernetes.io/name=spiffe-csi-driver"
+	SpireOIDCDiscoveryProviderDeploymentName = "spire-spiffe-oidc-discovery-provider"
+	SpireOIDCDiscoveryProviderPodLabel       = "app.kubernetes.io/name=spiffe-oidc-discovery-provider"
 
 	DefaultInterval = 10 * time.Second
 	ShortInterval   = 5 * time.Second


### PR DESCRIPTION
**### Tests the complete installation flow of SPIRE OIDC Discovery Provider by:**

1. Creating a SpireOIDCDiscoveryProvider custom resource
2. Validating that the operator successfully creates required Kubernetes resources
3. Ensuring the OIDC discovery service is running and available


**### Test Validation**
The test now properly validates:

1.  SpireOIDCConfigMapGeneration condition = "True"
2.  SpireOIDCDeploymentGeneration condition = "True"
3.  Deployment spire-spiffe-oidc-discovery-provider is Available
