### PR TITLE
SPIRE-213: upgrade spire-operands and operator version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.2.0
+VERSION ?= 1.0.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2025-09-03T15:14:06Z"
+    createdAt: "2025-10-08T08:13:05Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -46,7 +46,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v0.2.0
+  name: zero-trust-workload-identity-manager.v1.0.0
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -329,15 +329,15 @@ spec:
                 - name: OPERATOR_NAME
                   value: zero-trust-workload-identity-manager
                 - name: RELATED_IMAGE_SPIRE_SERVER
-                  value: ghcr.io/spiffe/spire-server:1.12.4
+                  value: ghcr.io/spiffe/spire-server:1.13.1
                 - name: RELATED_IMAGE_SPIRE_AGENT
-                  value: ghcr.io/spiffe/spire-agent:1.12.4
+                  value: ghcr.io/spiffe/spire-agent:1.13.1
                 - name: RELATED_IMAGE_SPIFFE_CSI_DRIVER
-                  value: ghcr.io/spiffe/spiffe-csi-driver:0.2.7
+                  value: ghcr.io/spiffe/spiffe-csi-driver:0.2.8
                 - name: RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER
-                  value: ghcr.io/spiffe/oidc-discovery-provider:1.12.4
+                  value: ghcr.io/spiffe/oidc-discovery-provider:1.13.1
                 - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
-                  value: ghcr.io/spiffe/spire-controller-manager:0.6.2
+                  value: ghcr.io/spiffe/spire-controller-manager:0.6.3
                 - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
                   value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
                 - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
@@ -401,18 +401,18 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: ghcr.io/spiffe/spire-server:1.12.4
+  - image: ghcr.io/spiffe/spire-server:1.13.1
     name: spire-server
-  - image: ghcr.io/spiffe/spire-agent:1.12.4
+  - image: ghcr.io/spiffe/spire-agent:1.13.1
     name: spire-agent
-  - image: ghcr.io/spiffe/spiffe-csi-driver:0.2.7
+  - image: ghcr.io/spiffe/spiffe-csi-driver:0.2.8
     name: spiffe-csi-driver
-  - image: ghcr.io/spiffe/oidc-discovery-provider:1.12.4
+  - image: ghcr.io/spiffe/oidc-discovery-provider:1.13.1
     name: spire-oidc-discovery-provider
-  - image: ghcr.io/spiffe/spire-controller-manager:0.6.2
+  - image: ghcr.io/spiffe/spire-controller-manager:0.6.3
     name: spire-controller-manager
   - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
     name: node-driver-registrar
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container
-  version: 0.2.0
+  version: 1.0.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,15 +63,15 @@ spec:
         - name: OPERATOR_NAME
           value: zero-trust-workload-identity-manager
         - name: RELATED_IMAGE_SPIRE_SERVER
-          value: ghcr.io/spiffe/spire-server:1.12.4
+          value: ghcr.io/spiffe/spire-server:1.13.1
         - name: RELATED_IMAGE_SPIRE_AGENT
-          value: ghcr.io/spiffe/spire-agent:1.12.4
+          value: ghcr.io/spiffe/spire-agent:1.13.1
         - name: RELATED_IMAGE_SPIFFE_CSI_DRIVER
-          value: ghcr.io/spiffe/spiffe-csi-driver:0.2.7
+          value: ghcr.io/spiffe/spiffe-csi-driver:0.2.8
         - name: RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER
-          value: ghcr.io/spiffe/oidc-discovery-provider:1.12.4
+          value: ghcr.io/spiffe/oidc-discovery-provider:1.13.1
         - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
-          value: ghcr.io/spiffe/spire-controller-manager:0.6.2
+          value: ghcr.io/spiffe/spire-controller-manager:0.6.3
         - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
           value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
         - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,12 +8,12 @@ var (
 	SHORTCOMMIT string
 
 	// Operator version (informational)
-	OperatorVersion string = "0.2.0"
+	OperatorVersion string = "1.0.0"
 
 	// Per-component versions (used for app.kubernetes.io/version labels)
-	SpiffeCsiVersion                  string = "0.2.7"
-	SpireAgentVersion                 string = "1.12.4"
-	SpireControllerManagerVersion     string = "0.6.2"
-	SpireOIDCDiscoveryProviderVersion string = "1.12.4"
-	SpireServerVersion                string = "1.12.4"
+	SpiffeCsiVersion                  string = "0.2.8"
+	SpireAgentVersion                 string = "1.13.1"
+	SpireControllerManagerVersion     string = "0.6.3"
+	SpireOIDCDiscoveryProviderVersion string = "1.13.1"
+	SpireServerVersion                string = "1.13.1"
 )


### PR DESCRIPTION
This PR upgrades SPIRE operands and operator version. Versions are being upgrade from:

`operator`: `0.2.0` ==> `1.0.0`
`spiffe CSI`: `0.2.7` ==> `0.2.8`
`spire agent`: `1.12.4` ==> `1.13.1`
`spire controller manager`: `0.6.2` ==> `0.6.3`
`spire OIDC discovery provider`: `1.12.4` ==> `1.13.1`
`spire server`: `1.12.4` ==> `1.13.1`