### PR TITLE
SPIRE-218: Removes the re-queue logic in case of the user input validation error

### DIFF
--- a/pkg/controller/spire-oidc-discovery-provider/controller.go
+++ b/pkg/controller/spire-oidc-discovery-provider/controller.go
@@ -3,6 +3,7 @@ package spire_oidc_discovery_provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -135,7 +136,8 @@ func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, re
 			Reason:  "InvalidJWTIssuerURL",
 			Message: fmt.Sprintf("JWT issuer URL validation failed: %v", err),
 		}
-		return ctrl.Result{}, err
+		// do not requeue if the user input validation error exist.
+		return ctrl.Result{}, nil
 	}
 
 	// Only set to true if the condition previously existed as false

--- a/pkg/controller/spire-server/controller.go
+++ b/pkg/controller/spire-server/controller.go
@@ -139,7 +139,8 @@ func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			Reason:  "InvalidJWTIssuerURL",
 			Message: fmt.Sprintf("JWT issuer URL validation failed: %v", err),
 		}
-		return ctrl.Result{}, err
+		// do not requeue if the user input validation error exist.
+		return ctrl.Result{}, nil
 	}
 	// Only set to true if the condition previously existed as false
 	existingCondition := apimeta.FindStatusCondition(server.Status.ConditionalStatus.Conditions, ConfigurationValidation)
@@ -153,7 +154,8 @@ func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Perform TTL validation and handle warnings
 	if err := r.handleTTLValidation(ctx, &server, reconcileStatus); err != nil {
-		return ctrl.Result{}, err
+		// do not requeue if the user input validation error exist.
+		return ctrl.Result{}, nil
 	}
 
 	spireServerConfigMap, err := GenerateSpireServerConfigMap(&server.Spec)


### PR DESCRIPTION
This PR removes unnecessary re-queues in ZTWIM controller reconciliation loops. Validation errors and other non-retriable errors should not trigger re-queues as they won't resolve without user intervention, which would improve the operator's performance.