### PR TITLE
CNF-23399: Upgrade golangci-lint from v1.59.1 to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,36 @@
+version: "2"
 run:
   timeout: 5m
   allow-parallel-runners: true
-
+linters:
+  disable-all: true
+  enable:
+    - dupl
+    - errcheck
+    - ginkgolinter
+    - goconst
+    - gocyclo
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+formatters:
+  enable:
+    - gofmt
+    - goimports
 issues:
   # don't skip warning about doc comments
   # don't exclude the default set of lint
@@ -16,32 +45,3 @@ issues:
       linters:
         - dupl
         - lll
-linters:
-  disable-all: true
-  enable:
-    - dupl
-    - errcheck
-    - exportloopref
-    - ginkgolinter
-    - goconst
-    - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
-    - govet
-    - ineffassign
-    - lll
-    - misspell
-    - nakedret
-    - prealloc
-    - revive
-    - staticcheck
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-
-linters-settings:
-  revive:
-    rules:
-      - name: comment-spacings

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -250,7 +250,10 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint)
+	@[ -f "$(GOLANGCI_LINT)" ] || { \
+	set -e; \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION); \
+	}
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
## Summary
- Bumped golangci-lint from v1.59.1 to v2.12.2
- Migrated `.golangci.yml` to v2 format: moved `linters-settings` under `linters.settings`, moved `gofmt`/`goimports` to `formatters.enable`
- Removed deprecated `exportloopref` linter (unnecessary since Go 1.22+)
- Switched install method from `go install` to official install script
- Updated module path to `github.com/golangci/golangci-lint/v2/`

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [openshift/ingress-node-firewall#692](https://github.com/openshift/ingress-node-firewall/pull/692) | [CNF-23398](https://redhat.atlassian.net/browse/CNF-23398): Upgrade golangci-lint from v1.54.2 to v2.12.2 | Open |
| [openshift-kni/commatrix#480](https://github.com/openshift-kni/commatrix/pull/480) | [CNF-23208](https://redhat.atlassian.net/browse/CNF-23208): Upgrade golangci-lint from v1.63.4 to v2.12.2 | Open |

## Jira
- [CNF-23399](https://issues.redhat.com/browse/CNF-23399) — Upgrade golangci-lint from v1.59.1 to v2.12.2 in zero-trust-workload-identity-manager (Code Review)
- Epic: [CNF-23396](https://issues.redhat.com/browse/CNF-23396) — GolangCI-Lint v2 Upgrade (In Progress)

## Upstream References
- [golangci-lint v2 migration guide](https://golangci-lint.run/product/migration-guide/)

## Test Plan
- [ ] CI passes
- [ ] Lint checks pass with new v2 config
