### PR TITLE
SPIRE-450: Fix e2e test nodeSelector/tolerations for OpenShift CI

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -498,6 +498,11 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
+				{
+					Key:      "node-role.kubernetes.io/control-plane",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
 			}
 
 			err = utils.UpdateCRWithRetry(testCtx, k8sClient, spireServer, func() {

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -43,6 +43,6 @@ const (
 
 	DefaultInterval = 10 * time.Second
 	ShortInterval   = 5 * time.Second
-	DefaultTimeout  = 5 * time.Minute
+	DefaultTimeout  = 8 * time.Minute
 	ShortTimeout    = 2 * time.Minute
 )


### PR DESCRIPTION
- Add dual tolerations for both node-role.kubernetes.io/master and node-role.kubernetes.io/control-plane to avoid scheduling issues across Kind and OpenShift CI environments
- Increase WaitForStatefulSetReady timeout from 5m to 8m for this test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E tests updated to allow server scheduling on Kubernetes control‑plane nodes by adding the required toleration.
  * Extended E2E test timeout to reduce flakiness and improve stability for longer-running scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->