### PR TITLE
Add spiffe-helper sidecar injection webhook

### DIFF
--- a/bindata/spiffe-helper/spiffe-helper-mutating-webhook.yaml
+++ b/bindata/spiffe-helper/spiffe-helper-mutating-webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: spiffe-helper-sidecar-injector
+  labels:
+    app.kubernetes.io/name: spiffe-helper
+    app.kubernetes.io/instance: spire
+    app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+    app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+  - admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: spiffe-helper-webhook
+        namespace: zero-trust-workload-identity-manager
+        path: /mutate-pods-spiffe-helper
+    failurePolicy: Ignore
+    name: spiffe-helper.spiffe.openshift.io
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+    sideEffects: None

--- a/bindata/spiffe-helper/spiffe-helper-webhook-deployment.yaml
+++ b/bindata/spiffe-helper/spiffe-helper-webhook-deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spiffe-helper-webhook
+  namespace: zero-trust-workload-identity-manager
+  labels:
+    app.kubernetes.io/name: spiffe-helper
+    app.kubernetes.io/instance: spire
+    app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+    app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: spiffe-helper-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: spiffe-helper-webhook
+        app.kubernetes.io/instance: spire
+        app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+        app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+    spec:
+      serviceAccountName: controller-manager
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: webhook
+        image: controller:latest
+        command:
+        - /usr/bin/zero-trust-workload-identity-manager
+        args:
+        - --serve-webhook
+        - --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+        - --health-probe-bind-address=:8082
+        ports:
+        - containerPort: 9443
+          name: webhook
+          protocol: TCP
+        - containerPort: 8082
+          name: health
+          protocol: TCP
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: RELATED_IMAGE_SPIFFE_HELPER
+          value: ghcr.io/spiffe/spiffe-helper:0.11.0
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: spiffe-helper-webhook-certs
+      terminationGracePeriodSeconds: 10

--- a/bindata/spiffe-helper/spiffe-helper-webhook-service.yaml
+++ b/bindata/spiffe-helper/spiffe-helper-webhook-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spiffe-helper-webhook
+  namespace: zero-trust-workload-identity-manager
+  labels:
+    app.kubernetes.io/name: spiffe-helper
+    app.kubernetes.io/instance: spire
+    app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+    app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: spiffe-helper-webhook-certs
+spec:
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: spiffe-helper-webhook

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2026-02-23T10:55:35Z"
+    createdAt: "2026-03-04T19:58:03Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -344,6 +344,7 @@ spec:
         - apiGroups:
           - ""
           resourceNames:
+          - spiffe-helper-webhook
           - spire-agent
           - spire-controller-manager-webhook
           - spire-server
@@ -353,6 +354,25 @@ spec:
           verbs:
           - delete
           - get
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resourceNames:
+          - spiffe-helper-sidecar-injector
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - delete
+          - patch
           - update
         - apiGroups:
           - admissionregistration.k8s.io
@@ -397,6 +417,7 @@ spec:
         - apiGroups:
           - apps
           resourceNames:
+          - spiffe-helper-webhook
           - spire-spiffe-oidc-discovery-provider
           resources:
           - deployments
@@ -707,6 +728,10 @@ spec:
                   value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
                 - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
                   value: registry.access.redhat.com/ubi9:latest
+                - name: RELATED_IMAGE_SPIFFE_HELPER
+                  value: ghcr.io/spiffe/spiffe-helper:0.11.0
+                - name: RELATED_IMAGE_SPIFFE_HELPER_WEBHOOK
+                  value: controller:latest
                 - name: OPERATOR_LOG_LEVEL
                   value: "2"
                 - name: METRICS_BIND_ADDRESS
@@ -799,4 +824,8 @@ spec:
     name: node-driver-registrar
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container
+  - image: ghcr.io/spiffe/spiffe-helper:0.11.0
+    name: spiffe-helper
+  - image: controller:latest
+    name: spiffe-helper-webhook
   version: 1.0.0

--- a/cmd/zero-trust-workload-identity-manager/main.go
+++ b/cmd/zero-trust-workload-identity-manager/main.go
@@ -43,6 +43,7 @@ import (
 	operatoropenshiftiov1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
 	spiffeCsiDriverController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/spiffe-csi-driver"
+	spiffeHelperController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/spiffe-helper"
 	spireAgentController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/spire-agent"
 	spireOIDCDiscoveryProviderController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/spire-oidc-discovery-provider"
 	spireServerController "github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/spire-server"
@@ -88,6 +89,8 @@ func main() {
 		enableHTTP2          bool
 		logLevel             int
 		metricsCerts         string
+		serveWebhook         bool
+		webhookCertDir       string
 		metricsTLSOpts       []func(*tls.Config)
 		webhookTLSOpts       []func(*tls.Config)
 	)
@@ -105,6 +108,10 @@ func main() {
 	flag.StringVar(&metricsCerts, "metrics-cert-dir", "",
 		"Secret name containing the certificates for the metrics server which should be present in operator namespace. "+
 			"If not provided self-signed certificates will be used")
+	flag.BoolVar(&serveWebhook, "serve-webhook", false,
+		"Run in webhook server mode: only serve admission webhooks, skip controllers")
+	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs",
+		"Directory containing TLS certificates for the webhook server")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -121,6 +128,12 @@ func main() {
 		os.Exit(1)
 	}
 	setupLog.Info("Operator namespace configured", "namespace", operatorNamespace)
+
+	// Webhook-only mode: serve admission webhooks without controllers
+	if serveWebhook {
+		runWebhookServer(webhookCertDir, probeAddr, enableHTTP2, logLevel)
+		return
+	}
 
 	if !enableHTTP2 {
 		// if the enable-http2 flag is false (the default), http/2 should be disabled
@@ -270,6 +283,14 @@ func main() {
 		exitOnError(err, "unable to setup spire OIDC discovery provider controller manager")
 	}
 
+	spiffeHelperControllerManager, err := spiffeHelperController.New(mgr)
+	if err != nil {
+		exitOnError(err, "unable to set up spiffe helper controller manager")
+	}
+	if err = spiffeHelperControllerManager.SetupWithManager(mgr); err != nil {
+		exitOnError(err, "unable to setup spiffe helper controller manager")
+	}
+
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		exitOnError(err, "unable to set up health check")
 	}
@@ -289,4 +310,44 @@ func exitOnError(err error, logMessage string) {
 		setupLog.Error(err, logMessage)
 		os.Exit(1)
 	}
+}
+
+// runWebhookServer starts a minimal manager that only serves admission webhooks
+func runWebhookServer(certDir, probeAddr string, enableHTTP2 bool, logLevel int) {
+	setupLog.Info("starting in webhook server mode")
+
+	var webhookTLSOpts []func(*tls.Config)
+	if !enableHTTP2 {
+		webhookTLSOpts = append(webhookTLSOpts, func(c *tls.Config) {
+			c.NextProtos = []string{"http/1.1"}
+		})
+	}
+
+	webhookServer := webhook.NewServer(webhook.Options{
+		TLSOpts: webhookTLSOpts,
+		CertDir: certDir,
+	})
+
+	config := ctrl.GetConfigOrDie()
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme:                 scheme,
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: probeAddr,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+	})
+	exitOnError(err, "unable to start webhook manager")
+
+	spiffeHelperInjector := spiffeHelperController.NewSpiffeHelperInjector()
+	mgr.GetWebhookServer().Register("/mutate-pods-spiffe-helper", &webhook.Admission{Handler: spiffeHelperInjector})
+
+	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		exitOnError(err, "unable to set up health check")
+	}
+	if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		exitOnError(err, "unable to set up ready check")
+	}
+
+	setupLog.Info("starting webhook server")
+	err = mgr.Start(ctrl.SetupSignalHandler())
+	exitOnError(err, "problem running webhook server")
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -92,6 +92,10 @@ spec:
           value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
         - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
           value: registry.access.redhat.com/ubi9:latest
+        - name: RELATED_IMAGE_SPIFFE_HELPER
+          value: ghcr.io/spiffe/spiffe-helper:0.11.0
+        - name: RELATED_IMAGE_SPIFFE_HELPER_WEBHOOK
+          value: controller:latest
         - name: OPERATOR_LOG_LEVEL
           value: "2"
         - name: METRICS_BIND_ADDRESS

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
+  - spiffe-helper-webhook
   - spire-agent
   - spire-controller-manager-webhook
   - spire-server
@@ -76,6 +77,25 @@ rules:
   verbs:
   - delete
   - get
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - spiffe-helper-sidecar-injector
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - delete
+  - patch
   - update
 - apiGroups:
   - admissionregistration.k8s.io
@@ -120,6 +140,7 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
+  - spiffe-helper-webhook
   - spire-spiffe-oidc-discovery-provider
   resources:
   - deployments

--- a/pkg/controller/spiffe-helper/controller.go
+++ b/pkg/controller/spiffe-helper/controller.go
@@ -1,0 +1,435 @@
+package spiffe_helper
+
+import (
+	"context"
+	"fmt"
+
+	"os"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/go-logr/logr"
+
+	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+	customClient "github.com/openshift/zero-trust-workload-identity-manager/pkg/client"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/status"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/operator/assets"
+)
+
+const (
+	MutatingWebhookAvailable   = "MutatingWebhookAvailable"
+	WebhookServiceAvailable    = "WebhookServiceAvailable"
+	WebhookDeploymentAvailable = "WebhookDeploymentAvailable"
+)
+
+// SpiffeHelperReconciler reconciles webhook resources for the spiffe-helper sidecar injector
+type SpiffeHelperReconciler struct {
+	ctrlClient    customClient.CustomCtrlClient
+	ctx           context.Context
+	eventRecorder record.EventRecorder
+	log           logr.Logger
+	scheme        *runtime.Scheme
+}
+
+// New returns a new SpiffeHelperReconciler instance
+func New(mgr ctrl.Manager) (*SpiffeHelperReconciler, error) {
+	c, err := customClient.NewCustomClient(mgr)
+	if err != nil {
+		return nil, err
+	}
+	return &SpiffeHelperReconciler{
+		ctrlClient:    c,
+		ctx:           context.Background(),
+		eventRecorder: mgr.GetEventRecorderFor(utils.ZeroTrustWorkloadIdentityManagerSpiffeHelperControllerName),
+		log:           ctrl.Log.WithName(utils.ZeroTrustWorkloadIdentityManagerSpiffeHelperControllerName),
+		scheme:        mgr.GetScheme(),
+	}, nil
+}
+
+func (r *SpiffeHelperReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.log.Info(fmt.Sprintf("reconciling %s", utils.ZeroTrustWorkloadIdentityManagerSpiffeHelperControllerName))
+
+	var csiDriver v1alpha1.SpiffeCSIDriver
+	if err := r.ctrlClient.Get(ctx, req.NamespacedName, &csiDriver); err != nil {
+		if kerrors.IsNotFound(err) {
+			r.log.Info("SpiffeCSIDriver resource not found. Ignoring since object must be deleted or not been created.")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	statusMgr := status.NewManager(r.ctrlClient)
+	defer func() {
+		if err := statusMgr.ApplyStatus(ctx, &csiDriver, func() *v1alpha1.ConditionalStatus {
+			return &csiDriver.Status.ConditionalStatus
+		}); err != nil {
+			r.log.Error(err, "failed to update status")
+		}
+	}()
+
+	createOnlyMode := utils.IsInCreateOnlyMode()
+
+	// Reconcile MutatingWebhookConfiguration
+	if err := r.reconcileMutatingWebhook(ctx, &csiDriver, statusMgr, createOnlyMode); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Reconcile webhook Service
+	if err := r.reconcileWebhookService(ctx, &csiDriver, statusMgr, createOnlyMode); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Reconcile webhook Deployment
+	if err := r.reconcileWebhookDeployment(ctx, &csiDriver, statusMgr, createOnlyMode); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *SpiffeHelperReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	mapFunc := func(ctx context.Context, _ client.Object) []reconcile.Request {
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name: "cluster",
+				},
+			},
+		}
+	}
+
+	controllerManagedResourcePredicates := builder.WithPredicates(utils.ControllerManagedResourcesForComponent(utils.ComponentSidecarInjector))
+
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.SpiffeCSIDriver{}, builder.WithPredicates(utils.GenerationOrOwnerReferenceChangedPredicate)).
+		Named(utils.ZeroTrustWorkloadIdentityManagerSpiffeHelperControllerName).
+		Watches(&admissionregistrationv1.MutatingWebhookConfiguration{}, handler.EnqueueRequestsFromMapFunc(mapFunc), controllerManagedResourcePredicates).
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(mapFunc), controllerManagedResourcePredicates).
+		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(mapFunc), controllerManagedResourcePredicates).
+		Complete(r)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// reconcileMutatingWebhook reconciles the MutatingWebhookConfiguration
+func (r *SpiffeHelperReconciler) reconcileMutatingWebhook(ctx context.Context, csiDriver *v1alpha1.SpiffeCSIDriver, statusMgr *status.Manager, createOnlyMode bool) error {
+	desired := getSpiffeHelperMutatingWebhookConfiguration(csiDriver.Spec.Labels)
+
+	if err := controllerutil.SetControllerReference(csiDriver, desired, r.scheme); err != nil {
+		r.log.Error(err, "failed to set controller reference on mutating webhook")
+		statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonFailed,
+			fmt.Sprintf("Failed to set owner reference on MutatingWebhookConfiguration: %v", err),
+			metav1.ConditionFalse)
+		return err
+	}
+
+	existing := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: desired.Name}, existing)
+
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to get mutating webhook")
+			statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonFailed,
+				fmt.Sprintf("Failed to get MutatingWebhookConfiguration: %v", err),
+				metav1.ConditionFalse)
+			return err
+		}
+
+		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			r.log.Error(err, "failed to create mutating webhook")
+			statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonFailed,
+				fmt.Sprintf("Failed to create MutatingWebhookConfiguration: %v", err),
+				metav1.ConditionFalse)
+			return err
+		}
+
+		r.log.Info("Created MutatingWebhookConfiguration", "name", desired.Name)
+		statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonReady,
+			"MutatingWebhookConfiguration available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	if createOnlyMode {
+		r.log.V(1).Info("MutatingWebhookConfiguration exists, skipping update due to create-only mode", "name", desired.Name)
+		statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonReady,
+			"MutatingWebhookConfiguration available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	// Preserve externally managed fields
+	desired.ResourceVersion = existing.ResourceVersion
+
+	// Build lookup by webhook name for safe matching
+	existingByName := make(map[string]admissionregistrationv1.MutatingWebhook, len(existing.Webhooks))
+	for _, wh := range existing.Webhooks {
+		existingByName[wh.Name] = wh
+	}
+	for i := range desired.Webhooks {
+		existingWH, ok := existingByName[desired.Webhooks[i].Name]
+		if !ok {
+			continue
+		}
+		// Preserve caBundle — injected by service-ca-operator
+		if len(existingWH.ClientConfig.CABundle) > 0 {
+			desired.Webhooks[i].ClientConfig.CABundle = existingWH.ClientConfig.CABundle
+		}
+		// Preserve service port — only when desired doesn't explicitly set one
+		if existingWH.ClientConfig.Service != nil &&
+			desired.Webhooks[i].ClientConfig.Service != nil &&
+			desired.Webhooks[i].ClientConfig.Service.Port == nil &&
+			existingWH.ClientConfig.Service.Port != nil {
+			desired.Webhooks[i].ClientConfig.Service.Port = existingWH.ClientConfig.Service.Port
+		}
+	}
+
+	if !utils.ResourceNeedsUpdate(existing, desired) {
+		r.log.V(1).Info("MutatingWebhookConfiguration is up to date", "name", desired.Name)
+		statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonReady,
+			"MutatingWebhookConfiguration available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	if err := r.ctrlClient.Update(ctx, desired); err != nil {
+		r.log.Error(err, "failed to update mutating webhook")
+		statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonFailed,
+			fmt.Sprintf("Failed to update MutatingWebhookConfiguration: %v", err),
+			metav1.ConditionFalse)
+		return err
+	}
+
+	r.log.Info("Updated MutatingWebhookConfiguration", "name", desired.Name)
+	statusMgr.AddCondition(MutatingWebhookAvailable, v1alpha1.ReasonReady,
+		"MutatingWebhookConfiguration available",
+		metav1.ConditionTrue)
+	return nil
+}
+
+// reconcileWebhookService reconciles the Service for the webhook
+func (r *SpiffeHelperReconciler) reconcileWebhookService(ctx context.Context, csiDriver *v1alpha1.SpiffeCSIDriver, statusMgr *status.Manager, createOnlyMode bool) error {
+	desired := getSpiffeHelperWebhookService(csiDriver.Spec.Labels)
+
+	if err := controllerutil.SetControllerReference(csiDriver, desired, r.scheme); err != nil {
+		r.log.Error(err, "failed to set controller reference on webhook service")
+		statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonFailed,
+			fmt.Sprintf("Failed to set owner reference on webhook Service: %v", err),
+			metav1.ConditionFalse)
+		return err
+	}
+
+	existing := &corev1.Service{}
+	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to get webhook service")
+			statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonFailed,
+				fmt.Sprintf("Failed to get webhook Service: %v", err),
+				metav1.ConditionFalse)
+			return err
+		}
+
+		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			r.log.Error(err, "failed to create webhook service")
+			statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonFailed,
+				fmt.Sprintf("Failed to create webhook Service: %v", err),
+				metav1.ConditionFalse)
+			return err
+		}
+
+		r.log.Info("Created webhook Service", "name", desired.Name, "namespace", desired.Namespace)
+		statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonReady,
+			"Webhook Service available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	if createOnlyMode {
+		r.log.V(1).Info("Webhook Service exists, skipping update due to create-only mode", "name", desired.Name)
+		statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonReady,
+			"Webhook Service available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	// Preserve Kubernetes-managed fields
+	desired.ResourceVersion = existing.ResourceVersion
+	desired.Spec.ClusterIP = existing.Spec.ClusterIP
+	desired.Spec.ClusterIPs = existing.Spec.ClusterIPs
+	desired.Spec.IPFamilies = existing.Spec.IPFamilies
+	desired.Spec.IPFamilyPolicy = existing.Spec.IPFamilyPolicy
+	desired.Spec.InternalTrafficPolicy = existing.Spec.InternalTrafficPolicy
+	desired.Spec.SessionAffinity = existing.Spec.SessionAffinity
+	if existing.Spec.HealthCheckNodePort != 0 {
+		desired.Spec.HealthCheckNodePort = existing.Spec.HealthCheckNodePort
+	}
+
+	for i := range desired.Spec.Ports {
+		if desired.Spec.Ports[i].Protocol == "" {
+			desired.Spec.Ports[i].Protocol = corev1.ProtocolTCP
+		}
+	}
+
+	if !utils.ResourceNeedsUpdate(existing, desired) {
+		r.log.V(1).Info("Webhook Service is up to date", "name", desired.Name)
+		statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonReady,
+			"Webhook Service available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	if err := r.ctrlClient.Update(ctx, desired); err != nil {
+		r.log.Error(err, "failed to update webhook service")
+		statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonFailed,
+			fmt.Sprintf("Failed to update webhook Service: %v", err),
+			metav1.ConditionFalse)
+		return err
+	}
+
+	r.log.Info("Updated webhook Service", "name", desired.Name, "namespace", desired.Namespace)
+	statusMgr.AddCondition(WebhookServiceAvailable, v1alpha1.ReasonReady,
+		"Webhook Service available",
+		metav1.ConditionTrue)
+	return nil
+}
+
+// getSpiffeHelperMutatingWebhookConfiguration returns the MutatingWebhookConfiguration with proper labels
+func getSpiffeHelperMutatingWebhookConfiguration(customLabels map[string]string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	webhook := utils.DecodeMutatingWebhookConfigurationByBytes(assets.MustAsset(utils.SpiffeHelperMutatingWebhookConfigurationAssetName))
+	webhook.Labels = utils.SpiffeHelperLabels(customLabels)
+	for i := range webhook.Webhooks {
+		if webhook.Webhooks[i].ClientConfig.Service != nil {
+			webhook.Webhooks[i].ClientConfig.Service.Namespace = utils.GetOperatorNamespace()
+		}
+	}
+	return webhook
+}
+
+// getSpiffeHelperWebhookService returns the webhook Service with proper labels
+func getSpiffeHelperWebhookService(customLabels map[string]string) *corev1.Service {
+	svc := utils.DecodeServiceObjBytes(assets.MustAsset(utils.SpiffeHelperWebhookServiceAssetName))
+	svc.Labels = utils.SpiffeHelperLabels(customLabels)
+	svc.Namespace = utils.GetOperatorNamespace()
+	return svc
+}
+
+// reconcileWebhookDeployment reconciles the Deployment for the webhook server
+func (r *SpiffeHelperReconciler) reconcileWebhookDeployment(ctx context.Context, csiDriver *v1alpha1.SpiffeCSIDriver, statusMgr *status.Manager, createOnlyMode bool) error {
+	desired := getSpiffeHelperWebhookDeployment(csiDriver.Spec.Labels)
+
+	if err := controllerutil.SetControllerReference(csiDriver, desired, r.scheme); err != nil {
+		r.log.Error(err, "failed to set controller reference on webhook deployment")
+		statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonFailed,
+			fmt.Sprintf("Failed to set owner reference on webhook Deployment: %v", err),
+			metav1.ConditionFalse)
+		return err
+	}
+
+	existing := &appsv1.Deployment{}
+	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to get webhook deployment")
+			statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonFailed,
+				fmt.Sprintf("Failed to get webhook Deployment: %v", err),
+				metav1.ConditionFalse)
+			return err
+		}
+
+		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			r.log.Error(err, "failed to create webhook deployment")
+			statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonFailed,
+				fmt.Sprintf("Failed to create webhook Deployment: %v", err),
+				metav1.ConditionFalse)
+			return err
+		}
+
+		r.log.Info("Created webhook Deployment", "name", desired.Name, "namespace", desired.Namespace)
+		statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonReady,
+			"Webhook Deployment available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	if createOnlyMode {
+		r.log.V(1).Info("Webhook Deployment exists, skipping update due to create-only mode", "name", desired.Name)
+		statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonReady,
+			"Webhook Deployment available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	desired.ResourceVersion = existing.ResourceVersion
+	if !utils.ResourceNeedsUpdate(existing, desired) {
+		r.log.V(1).Info("Webhook Deployment is up to date", "name", desired.Name)
+		statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonReady,
+			"Webhook Deployment available",
+			metav1.ConditionTrue)
+		return nil
+	}
+
+	if err := r.ctrlClient.Update(ctx, desired); err != nil {
+		r.log.Error(err, "failed to update webhook deployment")
+		statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonFailed,
+			fmt.Sprintf("Failed to update webhook Deployment: %v", err),
+			metav1.ConditionFalse)
+		return err
+	}
+
+	r.log.Info("Updated webhook Deployment", "name", desired.Name, "namespace", desired.Namespace)
+	statusMgr.AddCondition(WebhookDeploymentAvailable, v1alpha1.ReasonReady,
+		"Webhook Deployment available",
+		metav1.ConditionTrue)
+	return nil
+}
+
+// getSpiffeHelperWebhookDeployment returns the webhook Deployment with proper labels and image
+func getSpiffeHelperWebhookDeployment(customLabels map[string]string) *appsv1.Deployment {
+	deployment := utils.DecodeDeploymentObjBytes(assets.MustAsset(utils.SpiffeHelperWebhookDeploymentAssetName))
+	deployment.Labels = utils.SpiffeHelperLabels(customLabels)
+	deployment.Namespace = utils.GetOperatorNamespace()
+
+	// Set the webhook server image from RELATED_IMAGE env var
+	webhookImage := os.Getenv(utils.SpiffeHelperWebhookImageEnv)
+	if webhookImage != "" {
+		for i := range deployment.Spec.Template.Spec.Containers {
+			if deployment.Spec.Template.Spec.Containers[i].Name == "webhook" {
+				deployment.Spec.Template.Spec.Containers[i].Image = webhookImage
+			}
+		}
+	}
+
+	// Set RELATED_IMAGE_SPIFFE_HELPER from operator env
+	spiffeHelperImage := os.Getenv(utils.SpiffeHelperImageEnv)
+	if spiffeHelperImage != "" {
+		for i := range deployment.Spec.Template.Spec.Containers {
+			for j := range deployment.Spec.Template.Spec.Containers[i].Env {
+				if deployment.Spec.Template.Spec.Containers[i].Env[j].Name == utils.SpiffeHelperImageEnv {
+					deployment.Spec.Template.Spec.Containers[i].Env[j].Value = spiffeHelperImage
+				}
+			}
+		}
+	}
+
+	return deployment
+}

--- a/pkg/controller/spiffe-helper/controller_test.go
+++ b/pkg/controller/spiffe-helper/controller_test.go
@@ -1,0 +1,338 @@
+package spiffe_helper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/client/fakes"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/status"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newTestReconciler(fakeClient *fakes.FakeCustomCtrlClient) *SpiffeHelperReconciler {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = admissionregistrationv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	return &SpiffeHelperReconciler{
+		ctrlClient:    fakeClient,
+		ctx:           context.Background(),
+		log:           logr.Discard(),
+		scheme:        scheme,
+		eventRecorder: record.NewFakeRecorder(100),
+	}
+}
+
+func TestGetSpiffeHelperMutatingWebhookConfiguration(t *testing.T) {
+	tests := []struct {
+		name         string
+		customLabels map[string]string
+	}{
+		{
+			name:         "without custom labels",
+			customLabels: nil,
+		},
+		{
+			name: "with custom labels",
+			customLabels: map[string]string{
+				"admission-type": "mutating",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := getSpiffeHelperMutatingWebhookConfiguration(tt.customLabels)
+
+			if webhook == nil {
+				t.Fatal("Expected MutatingWebhookConfiguration, got nil")
+			}
+
+			if webhook.Name != "spiffe-helper-sidecar-injector" {
+				t.Errorf("Expected name 'spiffe-helper-sidecar-injector', got '%s'", webhook.Name)
+			}
+
+			if len(webhook.Labels) == 0 {
+				t.Error("Expected labels, got none")
+			}
+
+			if val, ok := webhook.Labels[utils.AppManagedByLabelKey]; !ok || val != utils.AppManagedByLabelValue {
+				t.Errorf("Expected label %s=%s", utils.AppManagedByLabelKey, utils.AppManagedByLabelValue)
+			}
+
+			if val, ok := webhook.Labels["app.kubernetes.io/component"]; !ok || val != utils.ComponentSidecarInjector {
+				t.Errorf("Expected label app.kubernetes.io/component=%s", utils.ComponentSidecarInjector)
+			}
+
+			for key, expectedValue := range tt.customLabels {
+				if val, ok := webhook.Labels[key]; !ok || val != expectedValue {
+					t.Errorf("Expected custom label '%s=%s', got '%s'", key, expectedValue, val)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileMutatingWebhook(t *testing.T) {
+	tests := []struct {
+		name           string
+		csiDriver      *v1alpha1.SpiffeCSIDriver
+		setupClient    func(*fakes.FakeCustomCtrlClient)
+		createOnlyMode bool
+		useEmptyScheme bool
+		expectError    bool
+		expectCreate   bool
+		expectUpdate   bool
+	}{
+		{
+			name: "create success",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spiffe-helper-sidecar-injector"))
+				fc.CreateReturns(nil)
+			},
+			expectError:  false,
+			expectCreate: true,
+		},
+		{
+			name: "create error",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spiffe-helper-sidecar-injector"))
+				fc.CreateReturns(errors.New("create failed"))
+			},
+			expectError: true,
+		},
+		{
+			name: "get error",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				fc.GetReturns(errors.New("connection refused"))
+			},
+			expectError: true,
+		},
+		{
+			name: "update success",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+				Spec: v1alpha1.SpiffeCSIDriverSpec{
+					CommonConfig: v1alpha1.CommonConfig{
+						Labels: map[string]string{"new-label": "new-value"},
+					},
+				},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingWebhook := &admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spiffe-helper-sidecar-injector",
+						ResourceVersion: "123",
+						Labels:          map[string]string{"old-label": "old-value"},
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if webhook, ok := obj.(*admissionregistrationv1.MutatingWebhookConfiguration); ok {
+						*webhook = *existingWebhook
+					}
+					return nil
+				}
+				fc.UpdateReturns(nil)
+			},
+			expectError:  false,
+			expectUpdate: true,
+		},
+		{
+			name: "update error",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+				Spec: v1alpha1.SpiffeCSIDriverSpec{
+					CommonConfig: v1alpha1.CommonConfig{
+						Labels: map[string]string{"new-label": "new-value"},
+					},
+				},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingWebhook := &admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spiffe-helper-sidecar-injector",
+						ResourceVersion: "123",
+						Labels:          map[string]string{"old-label": "old-value"},
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if webhook, ok := obj.(*admissionregistrationv1.MutatingWebhookConfiguration); ok {
+						*webhook = *existingWebhook
+					}
+					return nil
+				}
+				fc.UpdateReturns(errors.New("update conflict"))
+			},
+			expectError:  true,
+			expectUpdate: true,
+		},
+		{
+			name: "create only mode skips update",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+				Spec: v1alpha1.SpiffeCSIDriverSpec{
+					CommonConfig: v1alpha1.CommonConfig{
+						Labels: map[string]string{"new-label": "new-value"},
+					},
+				},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingWebhook := &admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spiffe-helper-sidecar-injector",
+						ResourceVersion: "123",
+						Labels:          map[string]string{"old-label": "old-value"},
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if webhook, ok := obj.(*admissionregistrationv1.MutatingWebhookConfiguration); ok {
+						*webhook = *existingWebhook
+					}
+					return nil
+				}
+			},
+			createOnlyMode: true,
+			expectError:    false,
+			expectUpdate:   false,
+		},
+		{
+			name: "set controller ref error",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient:    func(fc *fakes.FakeCustomCtrlClient) {},
+			useEmptyScheme: true,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := &fakes.FakeCustomCtrlClient{}
+			var reconciler *SpiffeHelperReconciler
+			if tt.useEmptyScheme {
+				reconciler = &SpiffeHelperReconciler{
+					ctrlClient:    fakeClient,
+					ctx:           context.Background(),
+					log:           logr.Discard(),
+					scheme:        runtime.NewScheme(),
+					eventRecorder: record.NewFakeRecorder(100),
+				}
+			} else {
+				reconciler = newTestReconciler(fakeClient)
+			}
+			tt.setupClient(fakeClient)
+
+			statusMgr := status.NewManager(fakeClient)
+			err := reconciler.reconcileMutatingWebhook(context.Background(), tt.csiDriver, statusMgr, tt.createOnlyMode)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+			if tt.expectCreate && fakeClient.CreateCallCount() != 1 {
+				t.Errorf("Expected Create to be called once, called %d times", fakeClient.CreateCallCount())
+			}
+			if !tt.expectCreate && !tt.expectError && fakeClient.CreateCallCount() != 0 {
+				t.Errorf("Expected Create not to be called, called %d times", fakeClient.CreateCallCount())
+			}
+			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
+				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
+			}
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
+				t.Error("Expected Update not to be called")
+			}
+		})
+	}
+}
+
+func TestReconcileWebhookService(t *testing.T) {
+	tests := []struct {
+		name           string
+		csiDriver      *v1alpha1.SpiffeCSIDriver
+		setupClient    func(*fakes.FakeCustomCtrlClient)
+		createOnlyMode bool
+		expectError    bool
+		expectCreate   bool
+	}{
+		{
+			name: "create success",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spiffe-helper-webhook"))
+				fc.CreateReturns(nil)
+			},
+			expectError:  false,
+			expectCreate: true,
+		},
+		{
+			name: "create error",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spiffe-helper-webhook"))
+				fc.CreateReturns(errors.New("create failed"))
+			},
+			expectError: true,
+		},
+		{
+			name: "get error",
+			csiDriver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				fc.GetReturns(errors.New("connection refused"))
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := &fakes.FakeCustomCtrlClient{}
+			reconciler := newTestReconciler(fakeClient)
+			tt.setupClient(fakeClient)
+
+			statusMgr := status.NewManager(fakeClient)
+			err := reconciler.reconcileWebhookService(context.Background(), tt.csiDriver, statusMgr, tt.createOnlyMode)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+			if tt.expectCreate && fakeClient.CreateCallCount() != 1 {
+				t.Errorf("Expected Create to be called once, called %d times", fakeClient.CreateCallCount())
+			}
+			if !tt.expectCreate && !tt.expectError && fakeClient.CreateCallCount() != 0 {
+				t.Errorf("Expected Create not to be called, called %d times", fakeClient.CreateCallCount())
+			}
+		})
+	}
+}

--- a/pkg/controller/spiffe-helper/webhook.go
+++ b/pkg/controller/spiffe-helper/webhook.go
@@ -1,0 +1,264 @@
+package spiffe_helper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
+)
+
+const (
+	// Annotation keys
+	AnnotationInjectHelper = "spiffe.openshift.io/inject-helper"
+	AnnotationCertDir      = "spiffe.openshift.io/cert-dir"
+	AnnotationHelperConfig = "spiffe.openshift.io/helper-config"
+
+	// Default values
+	DefaultCertDir      = "/var/run/secrets/tls"
+	DefaultHelperConfig = "spiffe-helper-config"
+
+	// Container and volume names
+	InitContainerName      = "spiffe-helper-init"
+	SidecarContainerName   = "spiffe-helper"
+	VolumeNameWorkloadAPI  = "spiffe-workload-api"
+	VolumeNameCerts        = "spiffe-certs"
+	VolumeNameHelperConfig = "spiffe-helper-config"
+	CSIDriverName          = "csi.spiffe.io"
+	WorkloadAPIMountPath   = "/spiffe-workload-api"
+	HelperConfigMountPath  = "/etc/spiffe-helper"
+)
+
+// SpiffeHelperInjector handles admission requests to inject spiffe-helper sidecars
+type SpiffeHelperInjector struct {
+	log logr.Logger
+}
+
+// NewSpiffeHelperInjector creates a new SpiffeHelperInjector
+func NewSpiffeHelperInjector() *SpiffeHelperInjector {
+	return &SpiffeHelperInjector{
+		log: ctrl.Log.WithName("spiffe-helper-injector"),
+	}
+}
+
+// Handle processes admission requests and injects spiffe-helper containers when annotated
+func (s *SpiffeHelperInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
+	pod := &corev1.Pod{}
+	if err := json.Unmarshal(req.Object.Raw, pod); err != nil {
+		s.log.Error(err, "failed to decode pod")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Check for injection annotation
+	annotations := pod.GetAnnotations()
+	if annotations == nil || annotations[AnnotationInjectHelper] != "true" {
+		return admission.Allowed("no injection requested")
+	}
+
+	// Skip if already injected
+	if hasSpiffeHelperContainers(pod) {
+		s.log.V(1).Info("spiffe-helper containers already present, skipping injection",
+			"pod", pod.Name, "namespace", pod.Namespace)
+		return admission.Allowed("already injected")
+	}
+
+	// Get image from environment variable
+	image := os.Getenv(utils.SpiffeHelperImageEnv)
+	if image == "" {
+		s.log.Error(nil, "RELATED_IMAGE_SPIFFE_HELPER not set")
+		return admission.Errored(http.StatusInternalServerError,
+			errMissingImage)
+	}
+
+	// Read optional annotations
+	certDir := getAnnotationOrDefault(annotations, AnnotationCertDir, DefaultCertDir)
+	helperConfigMap := getAnnotationOrDefault(annotations, AnnotationHelperConfig, DefaultHelperConfig)
+
+	// Inject containers and volumes
+	if err := injectSpiffeHelper(pod, image, certDir, helperConfigMap); err != nil {
+		s.log.Error(err, "failed to inject spiffe-helper", "pod", pod.Name, "namespace", pod.Namespace)
+		return admission.Errored(http.StatusUnprocessableEntity, err)
+	}
+
+	marshaledPod, err := json.Marshal(pod)
+	if err != nil {
+		s.log.Error(err, "failed to marshal mutated pod")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	s.log.Info("injected spiffe-helper sidecar", "pod", pod.Name, "namespace", pod.Namespace)
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+}
+
+// hasSpiffeHelperContainers checks if the pod already has both spiffe-helper containers
+func hasSpiffeHelperContainers(pod *corev1.Pod) bool {
+	hasInit := false
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == InitContainerName {
+			hasInit = true
+			break
+		}
+	}
+	hasSidecar := false
+	for _, c := range pod.Spec.Containers {
+		if c.Name == SidecarContainerName {
+			hasSidecar = true
+			break
+		}
+	}
+	return hasInit && hasSidecar
+}
+
+// getAnnotationOrDefault returns the annotation value or a default
+func getAnnotationOrDefault(annotations map[string]string, key, defaultValue string) string {
+	if val, ok := annotations[key]; ok && val != "" {
+		return val
+	}
+	return defaultValue
+}
+
+// injectSpiffeHelper adds init container, sidecar, and volumes to the pod
+func injectSpiffeHelper(pod *corev1.Pod, image, certDir, helperConfigMap string) error {
+	// Add volumes (only if not already present, reject if incompatible)
+	if err := ensureCompatibleVolume(pod, corev1.Volume{
+		Name: VolumeNameWorkloadAPI,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   CSIDriverName,
+				ReadOnly: boolPtr(true),
+			},
+		},
+	}); err != nil {
+		return err
+	}
+	if err := ensureCompatibleVolume(pod, corev1.Volume{
+		Name: VolumeNameCerts,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}); err != nil {
+		return err
+	}
+	if err := ensureCompatibleVolume(pod, corev1.Volume{
+		Name: VolumeNameHelperConfig,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: helperConfigMap,
+				},
+			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	// Common volume mounts for spiffe-helper containers
+	helperVolumeMounts := []corev1.VolumeMount{
+		{
+			Name:      VolumeNameWorkloadAPI,
+			MountPath: WorkloadAPIMountPath,
+			ReadOnly:  true,
+		},
+		{
+			Name:      VolumeNameCerts,
+			MountPath: certDir,
+		},
+		{
+			Name:      VolumeNameHelperConfig,
+			MountPath: HelperConfigMountPath,
+			ReadOnly:  true,
+		},
+	}
+
+	// Security context for compatibility with restricted namespaces
+	securityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: boolPtr(false),
+		RunAsNonRoot:             boolPtr(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	// Add init container
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+		Name:            InitContainerName,
+		Image:           image,
+		Args:            []string{"-config", "/etc/spiffe-helper/helper-init.conf"},
+		VolumeMounts:    helperVolumeMounts,
+		SecurityContext: securityContext,
+	})
+
+	// Add sidecar container
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name:            SidecarContainerName,
+		Image:           image,
+		Args:            []string{"-config", "/etc/spiffe-helper/helper.conf"},
+		VolumeMounts:    helperVolumeMounts,
+		SecurityContext: securityContext,
+	})
+
+	// Mount certs volume into existing containers (only if not already mounted)
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == SidecarContainerName {
+			continue
+		}
+		if !hasVolumeMount(&pod.Spec.Containers[i], VolumeNameCerts) {
+			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      VolumeNameCerts,
+					MountPath: certDir,
+					ReadOnly:  true,
+				},
+			)
+		}
+	}
+	return nil
+}
+
+// ensureCompatibleVolume adds a volume to the pod if absent, or returns an error if
+// a volume with the same name exists but has an incompatible source
+func ensureCompatibleVolume(pod *corev1.Pod, expected corev1.Volume) error {
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == expected.Name {
+			if !reflect.DeepEqual(v.VolumeSource, expected.VolumeSource) {
+				return fmt.Errorf("volume %q exists with incompatible source", expected.Name)
+			}
+			return nil
+		}
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, expected)
+	return nil
+}
+
+// hasVolumeMount checks if a container already has a volume mount with the given name
+func hasVolumeMount(container *corev1.Container, name string) bool {
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+var errMissingImage = errorf("RELATED_IMAGE_SPIFFE_HELPER environment variable not set")
+
+type constError string
+
+func errorf(s string) constError { return constError(s) }
+
+func (e constError) Error() string { return string(e) }

--- a/pkg/controller/spiffe-helper/webhook_test.go
+++ b/pkg/controller/spiffe-helper/webhook_test.go
@@ -1,0 +1,493 @@
+package spiffe_helper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func newAdmissionRequest(pod *corev1.Pod) admission.Request {
+	raw, _ := json.Marshal(pod)
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	}
+}
+
+func TestHandle_NoAnnotation(t *testing.T) {
+	injector := NewSpiffeHelperInjector()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if !resp.Allowed {
+		t.Error("Expected pod without annotation to be allowed")
+	}
+	if len(resp.Patches) != 0 {
+		t.Error("Expected no patches for pod without annotation")
+	}
+}
+
+func TestHandle_WithAnnotation(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_SPIFFE_HELPER", "ghcr.io/spiffe/spiffe-helper:0.11.0")
+
+	injector := NewSpiffeHelperInjector()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationInjectHelper: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if !resp.Allowed {
+		t.Error("Expected pod with annotation to be allowed")
+	}
+	if len(resp.Patches) == 0 {
+		t.Error("Expected patches for pod with injection annotation")
+	}
+
+	// Apply the patches by re-marshaling
+	mutatedPod := applyResponse(t, pod, resp)
+
+	// Verify init container
+	foundInit := false
+	for _, c := range mutatedPod.Spec.InitContainers {
+		if c.Name == InitContainerName {
+			foundInit = true
+			if c.Image != "ghcr.io/spiffe/spiffe-helper:0.11.0" {
+				t.Errorf("Expected init container image 'ghcr.io/spiffe/spiffe-helper:0.11.0', got '%s'", c.Image)
+			}
+		}
+	}
+	if !foundInit {
+		t.Error("Expected spiffe-helper-init init container to be injected")
+	}
+
+	// Verify sidecar container
+	foundSidecar := false
+	for _, c := range mutatedPod.Spec.Containers {
+		if c.Name == SidecarContainerName {
+			foundSidecar = true
+			if c.Image != "ghcr.io/spiffe/spiffe-helper:0.11.0" {
+				t.Errorf("Expected sidecar image 'ghcr.io/spiffe/spiffe-helper:0.11.0', got '%s'", c.Image)
+			}
+		}
+	}
+	if !foundSidecar {
+		t.Error("Expected spiffe-helper sidecar container to be injected")
+	}
+
+	// Verify volumes
+	volumeNames := map[string]bool{}
+	for _, v := range mutatedPod.Spec.Volumes {
+		volumeNames[v.Name] = true
+	}
+	for _, expected := range []string{VolumeNameWorkloadAPI, VolumeNameCerts, VolumeNameHelperConfig} {
+		if !volumeNames[expected] {
+			t.Errorf("Expected volume '%s' to be injected", expected)
+		}
+	}
+
+	// Verify cert volume is mounted read-only in the app container
+	for _, c := range mutatedPod.Spec.Containers {
+		if c.Name == "app" {
+			foundMount := false
+			for _, vm := range c.VolumeMounts {
+				if vm.Name == VolumeNameCerts {
+					foundMount = true
+					if !vm.ReadOnly {
+						t.Error("Expected cert volume mount in app container to be read-only")
+					}
+					if vm.MountPath != DefaultCertDir {
+						t.Errorf("Expected cert mount path '%s', got '%s'", DefaultCertDir, vm.MountPath)
+					}
+				}
+			}
+			if !foundMount {
+				t.Error("Expected cert volume to be mounted in app container")
+			}
+		}
+	}
+}
+
+func TestHandle_AlreadyInjected(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_SPIFFE_HELPER", "ghcr.io/spiffe/spiffe-helper:0.11.0")
+
+	injector := NewSpiffeHelperInjector()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationInjectHelper: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: InitContainerName, Image: "ghcr.io/spiffe/spiffe-helper:0.11.0"},
+			},
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+				{Name: SidecarContainerName, Image: "ghcr.io/spiffe/spiffe-helper:0.11.0"},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if !resp.Allowed {
+		t.Error("Expected already-injected pod to be allowed")
+	}
+	if len(resp.Patches) != 0 {
+		t.Error("Expected no patches for already-injected pod")
+	}
+}
+
+func TestHandle_CustomCertDir(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_SPIFFE_HELPER", "ghcr.io/spiffe/spiffe-helper:0.11.0")
+
+	injector := NewSpiffeHelperInjector()
+	customDir := "/custom/certs"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationInjectHelper: "true",
+				AnnotationCertDir:      customDir,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if !resp.Allowed {
+		t.Error("Expected pod to be allowed")
+	}
+
+	mutatedPod := applyResponse(t, pod, resp)
+
+	// Check cert mount path in app container
+	for _, c := range mutatedPod.Spec.Containers {
+		if c.Name == "app" {
+			for _, vm := range c.VolumeMounts {
+				if vm.Name == VolumeNameCerts {
+					if vm.MountPath != customDir {
+						t.Errorf("Expected custom cert dir '%s', got '%s'", customDir, vm.MountPath)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestHandle_CustomConfigMap(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_SPIFFE_HELPER", "ghcr.io/spiffe/spiffe-helper:0.11.0")
+
+	injector := NewSpiffeHelperInjector()
+	customCM := "my-helper-config"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationInjectHelper: "true",
+				AnnotationHelperConfig: customCM,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if !resp.Allowed {
+		t.Error("Expected pod to be allowed")
+	}
+
+	mutatedPod := applyResponse(t, pod, resp)
+
+	// Check configmap name in volume
+	for _, v := range mutatedPod.Spec.Volumes {
+		if v.Name == VolumeNameHelperConfig {
+			if v.ConfigMap == nil {
+				t.Fatal("Expected ConfigMap volume source")
+			}
+			if v.ConfigMap.Name != customCM {
+				t.Errorf("Expected configmap name '%s', got '%s'", customCM, v.ConfigMap.Name)
+			}
+		}
+	}
+}
+
+func TestHandle_MissingImage(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_SPIFFE_HELPER", "")
+
+	injector := NewSpiffeHelperInjector()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationInjectHelper: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if resp.Allowed {
+		t.Error("Expected pod to be rejected when image env var is missing")
+	}
+	if resp.Result.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, resp.Result.Code)
+	}
+}
+
+func TestHandle_IncompatibleVolume(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_SPIFFE_HELPER", "ghcr.io/spiffe/spiffe-helper:0.11.0")
+
+	injector := NewSpiffeHelperInjector()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationInjectHelper: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: VolumeNameCerts,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Path: "/some/path"},
+					},
+				},
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), newAdmissionRequest(pod))
+	if resp.Allowed {
+		t.Error("Expected pod with incompatible volume to be rejected")
+	}
+	if resp.Result.Code != http.StatusUnprocessableEntity {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnprocessableEntity, resp.Result.Code)
+	}
+}
+
+func TestHandle_InvalidPod(t *testing.T) {
+	injector := NewSpiffeHelperInjector()
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: []byte("invalid json"),
+			},
+		},
+	}
+
+	resp := injector.Handle(context.Background(), req)
+	if resp.Allowed {
+		t.Error("Expected invalid pod to be rejected")
+	}
+	if resp.Result.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, resp.Result.Code)
+	}
+}
+
+// applyResponse applies the actual JSON patches from the admission response to the original pod.
+// It re-invokes Handle to get the mutated raw bytes from PatchResponseFromRaw,
+// then unmarshals the result to verify the actual webhook output.
+func applyResponse(t *testing.T, original *corev1.Pod, resp admission.Response) *corev1.Pod {
+	t.Helper()
+
+	if len(resp.Patches) == 0 {
+		t.Fatal("expected patches but got none")
+	}
+
+	// Marshal the original pod and apply patches via jsonpatch
+	originalJSON, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal original pod: %v", err)
+	}
+
+	// Build a generic document, apply patches manually
+	var doc interface{}
+	if err := json.Unmarshal(originalJSON, &doc); err != nil {
+		t.Fatalf("failed to unmarshal original to generic: %v", err)
+	}
+
+	for _, patch := range resp.Patches {
+		doc = applyPatch(t, doc, patch.Operation, patch.Path, patch.Value)
+	}
+
+	patchedJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("failed to marshal patched doc: %v", err)
+	}
+
+	result := &corev1.Pod{}
+	if err := json.Unmarshal(patchedJSON, result); err != nil {
+		t.Fatalf("failed to unmarshal patched pod: %v", err)
+	}
+	return result
+}
+
+// applyPatch applies a single JSON patch operation to a document
+func applyPatch(t *testing.T, doc interface{}, op, path string, value interface{}) interface{} {
+	t.Helper()
+
+	parts := splitPath(path)
+	if len(parts) == 0 {
+		return value
+	}
+
+	return applyPatchRecursive(t, doc, op, parts, value)
+}
+
+func splitPath(path string) []string {
+	if path == "" || path == "/" {
+		return nil
+	}
+	// Remove leading /
+	if path[0] == '/' {
+		path = path[1:]
+	}
+	result := []string{}
+	for _, p := range splitOnSlash(path) {
+		// Unescape JSON pointer
+		p = replaceAll(p, "~1", "/")
+		p = replaceAll(p, "~0", "~")
+		result = append(result, p)
+	}
+	return result
+}
+
+func splitOnSlash(s string) []string {
+	result := []string{}
+	current := ""
+	for _, c := range s {
+		if c == '/' {
+			result = append(result, current)
+			current = ""
+		} else {
+			current += string(c)
+		}
+	}
+	result = append(result, current)
+	return result
+}
+
+func replaceAll(s, old, new string) string {
+	result := ""
+	for i := 0; i < len(s); i++ {
+		if i+len(old) <= len(s) && s[i:i+len(old)] == old {
+			result += new
+			i += len(old) - 1
+		} else {
+			result += string(s[i])
+		}
+	}
+	return result
+}
+
+func applyPatchRecursive(t *testing.T, doc interface{}, op string, parts []string, value interface{}) interface{} {
+	t.Helper()
+
+	if len(parts) == 1 {
+		key := parts[0]
+		switch d := doc.(type) {
+		case map[string]interface{}:
+			if op == "add" || op == "replace" {
+				d[key] = value
+			}
+			return d
+		case []interface{}:
+			if key == "-" {
+				return append(d, value)
+			}
+			// Numeric index
+			idx := 0
+			for _, c := range key {
+				idx = idx*10 + int(c-'0')
+			}
+			if op == "add" {
+				// Insert at index
+				result := make([]interface{}, len(d)+1)
+				copy(result, d[:idx])
+				result[idx] = value
+				copy(result[idx+1:], d[idx:])
+				return result
+			}
+			d[idx] = value
+			return d
+		default:
+			t.Fatalf("unexpected type at path: %T", doc)
+			return nil
+		}
+	}
+
+	key := parts[0]
+	rest := parts[1:]
+
+	switch d := doc.(type) {
+	case map[string]interface{}:
+		child, exists := d[key]
+		if !exists {
+			child = map[string]interface{}{}
+		}
+		d[key] = applyPatchRecursive(t, child, op, rest, value)
+		return d
+	case []interface{}:
+		idx := 0
+		for _, c := range key {
+			idx = idx*10 + int(c-'0')
+		}
+		d[idx] = applyPatchRecursive(t, d[idx], op, rest, value)
+		return d
+	default:
+		t.Fatalf("unexpected type at path %s: %T", key, doc)
+		return nil
+	}
+}

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -8,6 +8,7 @@ const (
 	ZeroTrustWorkloadIdentityManagerSpireAgentControllerName                 = "zero-trust-workload-identity-manager-spire-agent-controller"
 	ZeroTrustWorkloadIdentityManagerSpiffeCsiDriverControllerName            = "zero-trust-workload-identity-manager-spiffe-csi-driver-controller"
 	ZeroTrustWorkloadIdentityManagerSpireOIDCDiscoveryProviderControllerName = "zero-trust-workload-identity-manager-spire-oidc-discovery-provider-controller"
+	ZeroTrustWorkloadIdentityManagerSpiffeHelperControllerName               = "zero-trust-workload-identity-manager-spiffe-helper-controller"
 
 	OperatorNamespace = "zero-trust-workload-identity-manager"
 
@@ -48,6 +49,13 @@ const (
 	// Validating Webhook Configurations
 	SpireControllerManagerValidatingWebhookConfigurationAssetName = "spire-controller-manager/spire-controller-manager-webhook-validating-webhook.yaml"
 
+	// Mutating Webhook Configurations
+	SpiffeHelperMutatingWebhookConfigurationAssetName = "spiffe-helper/spiffe-helper-mutating-webhook.yaml"
+
+	// Spiffe Helper Service and Deployment
+	SpiffeHelperWebhookServiceAssetName    = "spiffe-helper/spiffe-helper-webhook-service.yaml"
+	SpiffeHelperWebhookDeploymentAssetName = "spiffe-helper/spiffe-helper-webhook-deployment.yaml"
+
 	// Service CA Certificate
 	ServiceCAAnnotationKey     = "service.beta.openshift.io/serving-cert-secret-name"
 	SpireServerServingCertName = "spire-server-serving-cert"
@@ -60,6 +68,8 @@ const (
 	SpireControllerManagerImageEnv     = "RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER"
 	NodeDriverRegistrarImageEnv        = "RELATED_IMAGE_NODE_DRIVER_REGISTRAR"
 	SpiffeCSIInitContainerImageEnv     = "RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER"
+	SpiffeHelperImageEnv               = "RELATED_IMAGE_SPIFFE_HELPER"
+	SpiffeHelperWebhookImageEnv        = "RELATED_IMAGE_SPIFFE_HELPER_WEBHOOK"
 
 	// Resource Kinds - used for validation and logging
 	ResourceKindSpireServer                = "SpireServer"

--- a/pkg/controller/utils/labels.go
+++ b/pkg/controller/utils/labels.go
@@ -17,10 +17,11 @@ const (
 	AppComponentLabelKey = "app.kubernetes.io/component"
 
 	// Component values
-	ComponentCSI          = "csi"
-	ComponentControlPlane = "control-plane"
-	ComponentNodeAgent    = "node-agent"
-	ComponentDiscovery    = "discovery"
+	ComponentCSI             = "csi"
+	ComponentControlPlane    = "control-plane"
+	ComponentNodeAgent       = "node-agent"
+	ComponentDiscovery       = "discovery"
+	ComponentSidecarInjector = "sidecar-injector"
 )
 
 // StandardizedLabels generates the new standardized label set for Kubernetes resources
@@ -62,6 +63,10 @@ func SpiffeCSIDriverLabels(customLabels map[string]string) map[string]string {
 
 func SpireControllerManagerLabels(customLabels map[string]string) map[string]string {
 	return StandardizedLabels("spire-controller-manager", ComponentControlPlane, version.SpireControllerManagerVersion, customLabels)
+}
+
+func SpiffeHelperLabels(customLabels map[string]string) map[string]string {
+	return StandardizedLabels("spiffe-helper", ComponentSidecarInjector, version.SpiffeHelperVersion, customLabels)
 }
 
 // hasControllerManagedLabelWithComponent checks if an object has both the managed-by label

--- a/pkg/controller/utils/resource_comparison.go
+++ b/pkg/controller/utils/resource_comparison.go
@@ -54,6 +54,8 @@ func ResourceNeedsUpdate(existing, desired client.Object) bool {
 		typeSpecificResult = CSIDriverNeedsUpdate(existingTyped, desired.(*storagev1.CSIDriver))
 	case *admissionregistrationv1.ValidatingWebhookConfiguration:
 		typeSpecificResult = ValidatingWebhookConfigurationNeedsUpdate(existingTyped, desired.(*admissionregistrationv1.ValidatingWebhookConfiguration))
+	case *admissionregistrationv1.MutatingWebhookConfiguration:
+		typeSpecificResult = MutatingWebhookConfigurationNeedsUpdate(existingTyped, desired.(*admissionregistrationv1.MutatingWebhookConfiguration))
 	case *securityv1.SecurityContextConstraints:
 		typeSpecificResult = SecurityContextConstraintsNeedsUpdate(existingTyped, desired.(*securityv1.SecurityContextConstraints))
 	case *spiffev1alpha1.ClusterSPIFFEID:
@@ -280,10 +282,19 @@ func fsGroupPolicyPtrsEqual(a, b *storagev1.FSGroupPolicy) bool {
 	return *a == *b
 }
 
-// ValidatingWebhookConfigurationNeedsUpdate checks if a ValidatingWebhookConfiguration needs updating
+// MutatingWebhookConfigurationNeedsUpdate checks if a MutatingWebhookConfiguration needs updating.
+// Uses DeepDerivative so that server-side defaulted fields in existing don't cause unnecessary updates.
+func MutatingWebhookConfigurationNeedsUpdate(existing, desired *admissionregistrationv1.MutatingWebhookConfiguration) bool {
+	if !equality.Semantic.DeepDerivative(desired.Webhooks, existing.Webhooks) {
+		return true
+	}
+	return false
+}
+
+// ValidatingWebhookConfigurationNeedsUpdate checks if a ValidatingWebhookConfiguration needs updating.
+// Uses DeepDerivative so that server-side defaulted fields in existing don't cause unnecessary updates.
 func ValidatingWebhookConfigurationNeedsUpdate(existing, desired *admissionregistrationv1.ValidatingWebhookConfiguration) bool {
-	// Compare webhooks - the main content of the configuration
-	if !equality.Semantic.DeepEqual(existing.Webhooks, desired.Webhooks) {
+	if !equality.Semantic.DeepDerivative(desired.Webhooks, existing.Webhooks) {
 		return true
 	}
 	return false

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -41,8 +42,9 @@ const (
 )
 
 func init() {
-	// Register core, storage and rbac schemes
+	// Register core, apps, storage and rbac schemes
 	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
 	_ = storagev1.AddToScheme(scheme)
 	_ = admissionregistrationv1.AddToScheme(scheme)
@@ -128,6 +130,22 @@ func DecodeValidatingWebhookConfigurationByBytes(objBytes []byte) *admissionregi
 		panic(err)
 	}
 	return obj.(*admissionregistrationv1.ValidatingWebhookConfiguration)
+}
+
+func DecodeDeploymentObjBytes(objBytes []byte) *appsv1.Deployment {
+	obj, err := runtime.Decode(codecs.UniversalDecoder(appsv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return obj.(*appsv1.Deployment)
+}
+
+func DecodeMutatingWebhookConfigurationByBytes(objBytes []byte) *admissionregistrationv1.MutatingWebhookConfiguration {
+	obj, err := runtime.Decode(codecs.UniversalDecoder(admissionregistrationv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return obj.(*admissionregistrationv1.MutatingWebhookConfiguration)
 }
 
 // SetLabel sets a label key/value on the given object metadata labels map.

--- a/pkg/controller/zero-trust-workload-identity-manager/controller.go
+++ b/pkg/controller/zero-trust-workload-identity-manager/controller.go
@@ -155,8 +155,10 @@ type ZeroTrustWorkloadIdentityManagerReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;delete,resourceNames=spire-bundle;spire-controller-manager-leader-election;spire-server-external-cert-reader;spire-oidc-external-cert-reader
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=update;delete,resourceNames=spire-controller-manager-webhook
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=patch;update;delete,resourceNames=spiffe-helper-sidecar-injector
 // +kubebuilder:rbac:groups="",resources=services,verbs=list;watch;create
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;update;delete,resourceNames=spire-server;spire-controller-manager-webhook;spire-agent;spire-spiffe-oidc-discovery-provider
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;update;delete,resourceNames=spiffe-helper-webhook;spire-server;spire-controller-manager-webhook;spire-agent;spire-spiffe-oidc-discovery-provider
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=list;watch;create
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;update;delete,resourceNames=spire-server;spire-agent;spire-spiffe-csi-driver;spire-spiffe-oidc-discovery-provider
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
@@ -180,7 +182,7 @@ type ZeroTrustWorkloadIdentityManagerReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=list;watch;create
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;update;delete,resourceNames=spire-agent;spire-spiffe-csi-driver
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;watch;create
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;update;delete,resourceNames=spire-spiffe-oidc-discovery-provider
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;update;delete,resourceNames=spiffe-helper-webhook;spire-spiffe-oidc-discovery-provider
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=list;watch;create
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;update;delete,resourceNames=spire-server
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=list;watch;create

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2,6 +2,9 @@
 // sources:
 // bindata/spiffe-csi/spiffe-csi-csi-driver.yaml
 // bindata/spiffe-csi/spiffe-csi-service-account.yaml
+// bindata/spiffe-helper/spiffe-helper-mutating-webhook.yaml
+// bindata/spiffe-helper/spiffe-helper-webhook-deployment.yaml
+// bindata/spiffe-helper/spiffe-helper-webhook-service.yaml
 // bindata/spire-agent/spire-agent-cluster-role-binding.yaml
 // bindata/spire-agent/spire-agent-cluster-role.yaml
 // bindata/spire-agent/spire-agent-service-account.yaml
@@ -144,6 +147,186 @@ func spiffeCsiSpiffeCsiServiceAccountYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "spiffe-csi/spiffe-csi-service-account.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _spiffeHelperSpiffeHelperMutatingWebhookYaml = []byte(`apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: spiffe-helper-sidecar-injector
+  labels:
+    app.kubernetes.io/name: spiffe-helper
+    app.kubernetes.io/instance: spire
+    app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+    app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+  - admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: spiffe-helper-webhook
+        namespace: zero-trust-workload-identity-manager
+        path: /mutate-pods-spiffe-helper
+    failurePolicy: Ignore
+    name: spiffe-helper.spiffe.openshift.io
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+    sideEffects: None
+`)
+
+func spiffeHelperSpiffeHelperMutatingWebhookYamlBytes() ([]byte, error) {
+	return _spiffeHelperSpiffeHelperMutatingWebhookYaml, nil
+}
+
+func spiffeHelperSpiffeHelperMutatingWebhookYaml() (*asset, error) {
+	bytes, err := spiffeHelperSpiffeHelperMutatingWebhookYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "spiffe-helper/spiffe-helper-mutating-webhook.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _spiffeHelperSpiffeHelperWebhookDeploymentYaml = []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spiffe-helper-webhook
+  namespace: zero-trust-workload-identity-manager
+  labels:
+    app.kubernetes.io/name: spiffe-helper
+    app.kubernetes.io/instance: spire
+    app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+    app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: spiffe-helper-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: spiffe-helper-webhook
+        app.kubernetes.io/instance: spire
+        app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+        app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+    spec:
+      serviceAccountName: controller-manager
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: webhook
+        image: controller:latest
+        command:
+        - /usr/bin/zero-trust-workload-identity-manager
+        args:
+        - --serve-webhook
+        - --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+        - --health-probe-bind-address=:8082
+        ports:
+        - containerPort: 9443
+          name: webhook
+          protocol: TCP
+        - containerPort: 8082
+          name: health
+          protocol: TCP
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: RELATED_IMAGE_SPIFFE_HELPER
+          value: ghcr.io/spiffe/spiffe-helper:0.11.0
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: spiffe-helper-webhook-certs
+      terminationGracePeriodSeconds: 10
+`)
+
+func spiffeHelperSpiffeHelperWebhookDeploymentYamlBytes() ([]byte, error) {
+	return _spiffeHelperSpiffeHelperWebhookDeploymentYaml, nil
+}
+
+func spiffeHelperSpiffeHelperWebhookDeploymentYaml() (*asset, error) {
+	bytes, err := spiffeHelperSpiffeHelperWebhookDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "spiffe-helper/spiffe-helper-webhook-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _spiffeHelperSpiffeHelperWebhookServiceYaml = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: spiffe-helper-webhook
+  namespace: zero-trust-workload-identity-manager
+  labels:
+    app.kubernetes.io/name: spiffe-helper
+    app.kubernetes.io/instance: spire
+    app.kubernetes.io/managed-by: "zero-trust-workload-identity-manager"
+    app.kubernetes.io/part-of: "zero-trust-workload-identity-manager"
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: spiffe-helper-webhook-certs
+spec:
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: spiffe-helper-webhook
+`)
+
+func spiffeHelperSpiffeHelperWebhookServiceYamlBytes() ([]byte, error) {
+	return _spiffeHelperSpiffeHelperWebhookServiceYaml, nil
+}
+
+func spiffeHelperSpiffeHelperWebhookServiceYaml() (*asset, error) {
+	bytes, err := spiffeHelperSpiffeHelperWebhookServiceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "spiffe-helper/spiffe-helper-webhook-service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1021,6 +1204,9 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"spiffe-csi/spiffe-csi-csi-driver.yaml":                                               spiffeCsiSpiffeCsiCsiDriverYaml,
 	"spiffe-csi/spiffe-csi-service-account.yaml":                                          spiffeCsiSpiffeCsiServiceAccountYaml,
+	"spiffe-helper/spiffe-helper-mutating-webhook.yaml":                                   spiffeHelperSpiffeHelperMutatingWebhookYaml,
+	"spiffe-helper/spiffe-helper-webhook-deployment.yaml":                                 spiffeHelperSpiffeHelperWebhookDeploymentYaml,
+	"spiffe-helper/spiffe-helper-webhook-service.yaml":                                    spiffeHelperSpiffeHelperWebhookServiceYaml,
 	"spire-agent/spire-agent-cluster-role-binding.yaml":                                   spireAgentSpireAgentClusterRoleBindingYaml,
 	"spire-agent/spire-agent-cluster-role.yaml":                                           spireAgentSpireAgentClusterRoleYaml,
 	"spire-agent/spire-agent-service-account.yaml":                                        spireAgentSpireAgentServiceAccountYaml,
@@ -1091,6 +1277,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"spiffe-csi": {nil, map[string]*bintree{
 		"spiffe-csi-csi-driver.yaml":      {spiffeCsiSpiffeCsiCsiDriverYaml, map[string]*bintree{}},
 		"spiffe-csi-service-account.yaml": {spiffeCsiSpiffeCsiServiceAccountYaml, map[string]*bintree{}},
+	}},
+	"spiffe-helper": {nil, map[string]*bintree{
+		"spiffe-helper-mutating-webhook.yaml":   {spiffeHelperSpiffeHelperMutatingWebhookYaml, map[string]*bintree{}},
+		"spiffe-helper-webhook-deployment.yaml": {spiffeHelperSpiffeHelperWebhookDeploymentYaml, map[string]*bintree{}},
+		"spiffe-helper-webhook-service.yaml":    {spiffeHelperSpiffeHelperWebhookServiceYaml, map[string]*bintree{}},
 	}},
 	"spire-agent": {nil, map[string]*bintree{
 		"spire-agent-cluster-role-binding.yaml": {spireAgentSpireAgentClusterRoleBindingYaml, map[string]*bintree{}},

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,4 +16,5 @@ var (
 	SpireControllerManagerVersion     string = "0.6.3"
 	SpireOIDCDiscoveryProviderVersion string = "1.13.3"
 	SpireServerVersion                string = "1.13.3"
+	SpiffeHelperVersion               string = "0.11.0"
 )


### PR DESCRIPTION
## Summary

- Add a MutatingAdmissionWebhook that automatically injects `spiffe-helper` init containers and sidecars into pods annotated with `spiffe.openshift.io/inject-helper: "true"`
- Eliminates manual sidecar configuration for applications needing on-disk TLS certificates from SPIRE
- Controller reconciles `MutatingWebhookConfiguration` and webhook `Service`, tied to `SpiffeCSIDriver` CR lifecycle

## What gets injected

| Resource | Purpose |
|---|---|
| Init container (`spiffe-helper-init`) | Fetches initial SVID certificates |
| Sidecar container (`spiffe-helper`) | Continuous certificate rotation |
| CSI volume (`csi.spiffe.io`) | SPIRE workload API socket |
| EmptyDir volume (`spiffe-certs`) | Certificate storage shared with app |
| ConfigMap volume (`spiffe-helper-config`) | Helper configuration |

## Files changed

**New files (6):**
- `bindata/spiffe-helper/` — MutatingWebhookConfiguration and Service YAML assets
- `pkg/controller/spiffe-helper/webhook.go` — Admission webhook handler
- `pkg/controller/spiffe-helper/controller.go` — Controller/reconciler
- `pkg/controller/spiffe-helper/webhook_test.go` — 7 webhook unit tests
- `pkg/controller/spiffe-helper/controller_test.go` — 10 controller unit tests

**Modified files (10):**
- `pkg/version/version.go` — `SpiffeHelperVersion = "0.11.0"`
- `pkg/controller/utils/` — Constants, labels, decoder, resource comparison for MutatingWebhookConfiguration
- `cmd/.../main.go` — Controller and webhook handler registration
- `config/manager/manager.yaml` — `RELATED_IMAGE_SPIFFE_HELPER` env var
- `config/rbac/role.yaml` — `mutatingwebhookconfigurations` permissions (auto-generated from kubebuilder markers)
- `pkg/operator/assets/bindata.go` — Regenerated

## Test plan

- [x] `make build` compiles successfully
- [x] `make test` — all unit tests pass (17 new tests + existing tests unaffected)
- [ ] Deploy to test cluster and verify:
  - Create pod with `spiffe.openshift.io/inject-helper: "true"` → init + sidecar injected
  - Create pod without annotation → no injection
  - Verify certs appear at `/var/run/secrets/tls/`

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic SPIFFE helper sidecar injection for pods via annotation; supports custom cert directory and custom helper ConfigMap.

* **Infrastructure**
  * Adds a webhook service and controller wiring, RBAC updates, deployment config for webhook port, and an env var to set the helper image; embeds webhook manifests as assets.

* **Tests**
  * Extensive unit tests covering controller reconciliation and webhook injection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->