### PR TITLE
Add E2E test for SpireAgent workload attestation (SPIRE-457)

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,6 +27,7 @@ import (
 	operatorv1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/test/e2e/utils"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
+	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,6 +58,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1.AddToScheme(scheme))
+	utilruntime.Must(spiffev1alpha1.AddToScheme(scheme))
 
 	// Create controller-runtime client
 	k8sClient, err = client.New(cfg, client.Options{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,10 +26,12 @@ import (
 	. "github.com/onsi/gomega"
 	operatorv1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/test/e2e/utils"
+	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -392,6 +394,163 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 
 			By("Verifying Upgradeable condition returns to True after recovery")
 			utils.WaitForUpgradeableStatus(testCtx, k8sClient, utils.OperatorNamespace, operatorConditionName, metav1.ConditionTrue, utils.ShortTimeout)
+		})
+	})
+
+	Context("SpireAgent attestation", func() {
+		It("Workload attestation should succeed and workload receives SVID", func() {
+			attestationNS := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: utils.AttestationTestNamespace,
+					Labels: map[string]string{
+						"kubernetes.io/metadata.name": utils.AttestationTestNamespace,
+					},
+				},
+			}
+			clusterSPIFFEID := &spiffev1alpha1.ClusterSPIFFEID{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "attestation-test",
+				},
+				Spec: spiffev1alpha1.ClusterSPIFFEIDSpec{
+					SPIFFEIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}",
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "attestation-test"},
+					},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": utils.AttestationTestNamespace,
+						},
+					},
+					ClassName: "zero-trust-workload-identity-manager-spire",
+				},
+			}
+
+			By("Creating attestation test namespace")
+			err := k8sClient.Create(testCtx, attestationNS)
+			Expect(err).NotTo(HaveOccurred(), "failed to create attestation test namespace")
+
+			By("Creating ClusterSPIFFEID for attestation test")
+			err = k8sClient.Create(testCtx, clusterSPIFFEID)
+			Expect(err).NotTo(HaveOccurred(), "failed to create ClusterSPIFFEID")
+
+			DeferCleanup(func(ctx context.Context) {
+				By("Deleting ClusterSPIFFEID")
+				_ = k8sClient.Delete(ctx, clusterSPIFFEID)
+				By("Deleting attestation test namespace")
+				_ = k8sClient.Delete(ctx, attestationNS)
+			})
+
+			By("Creating ServiceAccount")
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      utils.AttestationTestSA,
+					Namespace: utils.AttestationTestNamespace,
+				},
+			}
+			err = k8sClient.Create(testCtx, sa)
+			Expect(err).NotTo(HaveOccurred(), "failed to create ServiceAccount")
+
+			By("Creating spiffe-helper ConfigMap")
+			helperConf := `agent_address = "/spiffe-workload-api/spire-agent.sock"
+cert_dir = "/certs"
+svid_file_name = "svid.pem"
+svid_key_file_name = "svid_key.pem"
+svid_bundle_file_name = "bundle.pem"
+`
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      utils.SpiffeHelperConfigMapName,
+					Namespace: utils.AttestationTestNamespace,
+				},
+				Data: map[string]string{
+					"helper.conf": helperConf,
+				},
+			}
+			err = k8sClient.Create(testCtx, cm)
+			Expect(err).NotTo(HaveOccurred(), "failed to create spiffe-helper ConfigMap")
+
+			By("Creating attestation test pod with CSI volume and spiffe-helper")
+			readOnlyTrue := true
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      utils.AttestationTestPodName,
+					Namespace: utils.AttestationTestNamespace,
+					Labels:    map[string]string{"app": "attestation-test"},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: utils.AttestationTestSA,
+					Containers: []corev1.Container{
+						{
+							Name:  utils.SpiffeHelperContainerName,
+							Image: "ghcr.io/spiffe/spiffe-helper:0.8.0",
+							Args:  []string{"-config", "/run/spiffe-helper/helper.conf"},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "spiffe-workload-api", MountPath: "/spiffe-workload-api", ReadOnly: true},
+								{Name: "certs", MountPath: "/certs"},
+								{Name: "spiffe-helper-config", MountPath: "/run/spiffe-helper", ReadOnly: true},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+								RunAsNonRoot:             ptr.To(true),
+								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+							},
+						},
+						{
+							Name:    utils.AttestationTestAppContainer,
+							Image:   "busybox",
+							Command: []string{"sleep", "3600"},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "certs", MountPath: "/certs"},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+								RunAsNonRoot:             ptr.To(true),
+								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "spiffe-workload-api",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver:   "csi.spiffe.io",
+									ReadOnly: &readOnlyTrue,
+								},
+							},
+						},
+						{Name: "certs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{
+							Name: "spiffe-helper-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: utils.SpiffeHelperConfigMapName}},
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Create(testCtx, pod)
+			Expect(err).NotTo(HaveOccurred(), "failed to create attestation test pod")
+
+			By("Waiting for attestation test pod to become ready")
+			utils.WaitForPodReady(testCtx, clientset, utils.AttestationTestPodName, utils.AttestationTestNamespace, 3*utils.ShortTimeout)
+
+			By("Verifying SVID files exist in /certs/")
+			Eventually(func() string {
+				stdout, _, err := utils.ExecInPod(testCtx, utils.AttestationTestNamespace, utils.AttestationTestPodName, utils.AttestationTestAppContainer, []string{"ls", "/certs/"})
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "exec ls /certs/ failed: %v\n", err)
+					return ""
+				}
+				return stdout
+			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(
+				And(
+					ContainSubstring("svid.pem"),
+					ContainSubstring("svid_key.pem"),
+					ContainSubstring("bundle.pem"),
+				))
 		})
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -547,7 +547,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 					return ""
 				}
 				return stdout
-			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(
+			}).WithTimeout(utils.DefaultTimeout).WithPolling(utils.DefaultInterval).Should(
 				And(
 					ContainSubstring("svid.pem"),
 					ContainSubstring("svid_key.pem"),

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -399,11 +399,16 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 
 	Context("SpireAgent attestation", func() {
 		It("Workload attestation should succeed and workload receives SVID", func() {
+			attestationTestNamespace := "e2e-attestation-test"
+			attestationTestPodName := "attestation-test-pod"
+			attestationTestSA := "attestation-test-sa"
+			attestationTestAppContainer := "app"
+
 			attestationNS := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: utils.AttestationTestNamespace,
+					Name: attestationTestNamespace,
 					Labels: map[string]string{
-						"kubernetes.io/metadata.name": utils.AttestationTestNamespace,
+						"kubernetes.io/metadata.name": attestationTestNamespace,
 					},
 				},
 			}
@@ -418,7 +423,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 					},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"kubernetes.io/metadata.name": utils.AttestationTestNamespace,
+							"kubernetes.io/metadata.name": attestationTestNamespace,
 						},
 					},
 					ClassName: "zero-trust-workload-identity-manager-spire",
@@ -443,8 +448,8 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			By("Creating ServiceAccount")
 			sa := &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      utils.AttestationTestSA,
-					Namespace: utils.AttestationTestNamespace,
+					Name:      attestationTestSA,
+					Namespace: attestationTestNamespace,
 				},
 			}
 			err = k8sClient.Create(testCtx, sa)
@@ -455,7 +460,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			cm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      utils.SpiffeHelperConfigMapName,
-					Namespace: utils.AttestationTestNamespace,
+					Namespace: attestationTestNamespace,
 				},
 				Data: map[string]string{
 					"helper.conf": helperConf,
@@ -468,12 +473,12 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			readOnlyTrue := true
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      utils.AttestationTestPodName,
-					Namespace: utils.AttestationTestNamespace,
+					Name:      attestationTestPodName,
+					Namespace: attestationTestNamespace,
 					Labels:    map[string]string{"app": "attestation-test"},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: utils.AttestationTestSA,
+					ServiceAccountName: attestationTestSA,
 					Containers: []corev1.Container{
 						{
 							Name:  utils.SpiffeHelperContainerName,
@@ -493,7 +498,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 							},
 						},
 						{
-							Name:    utils.AttestationTestAppContainer,
+							Name:    attestationTestAppContainer,
 							Image:   "busybox",
 							Command: []string{"sleep", "3600"},
 							VolumeMounts: []corev1.VolumeMount{
@@ -532,11 +537,11 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create attestation test pod")
 
 			By("Waiting for attestation test pod to become ready")
-			utils.WaitForPodReady(testCtx, clientset, utils.AttestationTestPodName, utils.AttestationTestNamespace, 3*utils.ShortTimeout)
+			utils.WaitForPodReady(testCtx, clientset, attestationTestPodName, attestationTestNamespace, 3*utils.ShortTimeout)
 
 			By("Verifying SVID files exist in /certs/")
 			Eventually(func() string {
-				stdout, _, err := utils.ExecInPod(testCtx, utils.AttestationTestNamespace, utils.AttestationTestPodName, utils.AttestationTestAppContainer, []string{"ls", "/certs/"})
+				stdout, _, err := utils.ExecInPod(testCtx, attestationTestNamespace, attestationTestPodName, attestationTestAppContainer, []string{"ls", "/certs/"})
 				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "exec ls /certs/ failed: %v\n", err)
 					return ""

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,8 +31,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -493,6 +493,7 @@ svid_bundle_file_name = "bundle.pem"
 								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 								RunAsNonRoot:             ptr.To(true),
+								RunAsUser:                ptr.To(int64(1000)),
 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 							},
 						},
@@ -507,6 +508,7 @@ svid_bundle_file_name = "bundle.pem"
 								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 								RunAsNonRoot:             ptr.To(true),
+								RunAsUser:                ptr.To(int64(1000)),
 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 							},
 						},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -451,12 +451,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create ServiceAccount")
 
 			By("Creating spiffe-helper ConfigMap")
-			helperConf := `agent_address = "/spiffe-workload-api/spire-agent.sock"
-cert_dir = "/certs"
-svid_file_name = "svid.pem"
-svid_key_file_name = "svid_key.pem"
-svid_bundle_file_name = "bundle.pem"
-`
+			helperConf := utils.DefaultAttestationSpiffeHelperConfig().String()
 			cm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      utils.SpiffeHelperConfigMapName,
@@ -482,7 +477,7 @@ svid_bundle_file_name = "bundle.pem"
 					Containers: []corev1.Container{
 						{
 							Name:  utils.SpiffeHelperContainerName,
-							Image: "ghcr.io/spiffe/spiffe-helper:0.8.0",
+							Image: utils.SpiffeHelperImage,
 							Args:  []string{"-config", "/run/spiffe-helper/helper.conf"},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "spiffe-workload-api", MountPath: "/spiffe-workload-api", ReadOnly: true},

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -41,14 +41,10 @@ const (
 	SpireOIDCDiscoveryProviderConfigMapName  = "spire-spiffe-oidc-discovery-provider"
 	SpireOIDCDiscoveryProviderConfigKey      = "oidc-discovery-provider.conf"
 
-	// Attestation test namespace and workload identifiers
-	AttestationTestNamespace    = "e2e-attestation-test"
-	AttestationTestPodName      = "attestation-test-pod"
-	AttestationTestSA           = "attestation-test-sa"
-	SpiffeHelperConfigMapName   = "spiffe-helper-config"
-	SpiffeHelperContainerName   = "spiffe-helper"
-	SpiffeHelperImage           = "ghcr.io/spiffe/spiffe-helper:0.11.0"
-	AttestationTestAppContainer = "app"
+	// Spiffe-helper constants (reusable across tests)
+	SpiffeHelperConfigMapName = "spiffe-helper-config"
+	SpiffeHelperContainerName = "spiffe-helper"
+	SpiffeHelperImage         = "ghcr.io/spiffe/spiffe-helper:0.11.0"
 
 	DefaultInterval = 10 * time.Second
 	ShortInterval   = 5 * time.Second

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -41,6 +41,14 @@ const (
 	SpireOIDCDiscoveryProviderConfigMapName  = "spire-spiffe-oidc-discovery-provider"
 	SpireOIDCDiscoveryProviderConfigKey      = "oidc-discovery-provider.conf"
 
+	// Attestation test namespace and workload identifiers
+	AttestationTestNamespace    = "e2e-attestation-test"
+	AttestationTestPodName      = "attestation-test-pod"
+	AttestationTestSA           = "attestation-test-sa"
+	SpiffeHelperConfigMapName   = "spiffe-helper-config"
+	SpiffeHelperContainerName   = "spiffe-helper"
+	AttestationTestAppContainer = "app"
+
 	DefaultInterval = 10 * time.Second
 	ShortInterval   = 5 * time.Second
 	DefaultTimeout  = 5 * time.Minute

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -47,6 +47,7 @@ const (
 	AttestationTestSA           = "attestation-test-sa"
 	SpiffeHelperConfigMapName   = "spiffe-helper-config"
 	SpiffeHelperContainerName   = "spiffe-helper"
+	SpiffeHelperImage           = "ghcr.io/spiffe/spiffe-helper:0.11.0"
 	AttestationTestAppContainer = "app"
 
 	DefaultInterval = 10 * time.Second

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -41,7 +41,6 @@ const (
 	SpireOIDCDiscoveryProviderConfigMapName  = "spire-spiffe-oidc-discovery-provider"
 	SpireOIDCDiscoveryProviderConfigKey      = "oidc-discovery-provider.conf"
 
-	// Spiffe-helper constants (reusable across tests)
 	SpiffeHelperConfigMapName = "spiffe-helper-config"
 	SpiffeHelperContainerName = "spiffe-helper"
 	SpiffeHelperImage         = "ghcr.io/spiffe/spiffe-helper:0.11.0"

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -46,6 +46,36 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// SpiffeHelperConfig holds configuration for the spiffe-helper sidecar (helper.conf format).
+type SpiffeHelperConfig struct {
+	AgentAddress       string
+	CertDir            string
+	SvidFileName       string
+	SvidKeyFileName    string
+	SvidBundleFileName string
+}
+
+// DefaultAttestationSpiffeHelperConfig returns the default config for E2E attestation tests.
+func DefaultAttestationSpiffeHelperConfig() SpiffeHelperConfig {
+	return SpiffeHelperConfig{
+		AgentAddress:       "/spiffe-workload-api/spire-agent.sock",
+		CertDir:            "/certs",
+		SvidFileName:       "svid.pem",
+		SvidKeyFileName:    "svid_key.pem",
+		SvidBundleFileName: "bundle.pem",
+	}
+}
+
+// String returns the config as a TOML-like string for helper.conf.
+func (c SpiffeHelperConfig) String() string {
+	return fmt.Sprintf(`agent_address = %q
+cert_dir = %q
+svid_file_name = %q
+svid_key_file_name = %q
+svid_bundle_file_name = %q
+`, c.AgentAddress, c.CertDir, c.SvidFileName, c.SvidKeyFileName, c.SvidBundleFileName)
+}
+
 // GetTestDir returns the directory to write test results to
 func GetTestDir() string {
 	// Test is running in the Prow CI, use ARTIFACT_DIR environment variable

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -17,10 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -150,6 +152,50 @@ func WaitForPodRunning(ctx context.Context, clientset kubernetes.Interface, name
 		return true
 	}).WithTimeout(timeout).WithPolling(ShortInterval).Should(BeTrue(),
 		"pod '%s/%s' should become running within %v", namespace, name, timeout)
+}
+
+// WaitForPodReady waits for a specific pod to have Ready condition set to True within timeout
+func WaitForPodReady(ctx context.Context, clientset kubernetes.Interface, name, namespace string, timeout time.Duration) {
+	Eventually(func() bool {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "failed to get pod '%s/%s': %v\n", namespace, name, err)
+			return false
+		}
+
+		if !IsPodReady(pod) {
+			fmt.Fprintf(GinkgoWriter, "pod '%s/%s' not ready yet (phase=%s)\n", namespace, name, pod.Status.Phase)
+			return false
+		}
+
+		fmt.Fprintf(GinkgoWriter, "pod '%s/%s' is ready\n", namespace, name)
+		return true
+	}).WithTimeout(timeout).WithPolling(ShortInterval).Should(BeTrue(),
+		"pod '%s/%s' should become ready within %v", namespace, name, timeout)
+}
+
+// ExecInPod runs a command in a pod container and returns stdout, stderr, and error.
+// Uses oc exec when available (OpenShift) or kubectl as fallback.
+func ExecInPod(ctx context.Context, namespace, podName, containerName string, command []string) (stdout, stderr string, err error) {
+	cli := "oc"
+	if _, lookupErr := exec.LookPath("oc"); lookupErr != nil {
+		cli = "kubectl"
+	}
+
+	args := []string{"exec", podName, "-n", namespace, "-c", containerName, "--"}
+	args = append(args, command...)
+
+	cmd := exec.CommandContext(ctx, cli, args...)
+	cmd.Env = os.Environ()
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err = cmd.Run(); err != nil {
+		return stdoutBuf.String(), stderrBuf.String(), fmt.Errorf("exec %s %v: %w", cli, args, err)
+	}
+	return stdoutBuf.String(), stderrBuf.String(), nil
 }
 
 // IsDeploymentAvailable checks if a Deployment has the Available condition set to True


### PR DESCRIPTION
- Add spiffev1alpha1 to scheme for ClusterSPIFFEID support
- Add ExecInPod and WaitForPodReady helpers in test/e2e/utils
- Add attestation test constants (namespace, pod name, SA, etc.)
- Add Context('SpireAgent attestation') with workload attestation test
- Test creates ClusterSPIFFEID, pod with CSI + spiffe-helper, verifies SVID files