### PR TITLE
SPIRE-320: Remove shareProcessNamespace from spire-server statefulset

### DIFF
--- a/pkg/controller/spire-server/statefulset.go
+++ b/pkg/controller/spire-server/statefulset.go
@@ -164,7 +164,6 @@ func GenerateSpireServerStatefulSet(config *v1alpha1.SpireServerSpec,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:    "spire-server",
-					ShareProcessNamespace: ptr.To(true),
 					Containers: []corev1.Container{
 						{
 							SecurityContext: &corev1.SecurityContext{

--- a/pkg/controller/spire-server/statefulset_test.go
+++ b/pkg/controller/spire-server/statefulset_test.go
@@ -106,10 +106,6 @@ func TestGenerateSpireServerStatefulSet(t *testing.T) {
 			t.Errorf("Expected service account name 'spire-server', got %q", podSpec.ServiceAccountName)
 		}
 
-		if *podSpec.ShareProcessNamespace != true {
-			t.Errorf("Expected share process namespace to be true")
-		}
-
 		// Check volume count
 		expectedVolumeCount := 5
 		if len(podSpec.Volumes) != expectedVolumeCount {
@@ -545,7 +541,6 @@ func createReferenceStatefulSet(config *v1alpha1.SpireServerSpec, spireServerCon
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:    "spire-server",
-					ShareProcessNamespace: ptr.To(true),
 					Containers: []corev1.Container{
 						{
 							Name:            "spire-server",

--- a/pkg/controller/utils/resource_comparison_test.go
+++ b/pkg/controller/utils/resource_comparison_test.go
@@ -839,7 +839,6 @@ func TestStatefulSetNeedsUpdate(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						ServiceAccountName:    "test-sa",
-						ShareProcessNamespace: ptr.To(false),
 						DNSPolicy:             corev1.DNSClusterFirst,
 						NodeSelector:          map[string]string{"zone": "east"},
 						Affinity: &corev1.Affinity{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -85,7 +85,8 @@ func TestE2E(t *testing.T) {
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 
 	// Suite-level configuration
-	suiteConfig.Timeout = 20 * time.Minute // Global timeout per individual test
+	// Suite timeout must allow all test specs to complete; go test -timeout is 45m
+	suiteConfig.Timeout = 40 * time.Minute
 	suiteConfig.FailFast = false           // Continue after first failure to see all issues
 	suiteConfig.FlakeAttempts = 0          // Retry on flaky tests (helpful when deflaking tests)
 	suiteConfig.MustPassRepeatedly = 1     // Must pass repeatedly times (helpful when deflaking tests)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -489,8 +489,11 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			initialGen := statefulset.Generation
 
 			By("Patching SpireServer object with nodeSelector and tolerations to schedule Pod on control-plane Nodes")
+			// Use node-role.kubernetes.io/master for nodeSelector so the test works on both
+			// newly installed OCP 4.12+ clusters (control-plane label) and upgraded clusters
+			// (master label only). See https://access.redhat.com/solutions/7028754
 			expectedNodeSelector := map[string]string{
-				"node-role.kubernetes.io/control-plane": "",
+				"node-role.kubernetes.io/master": "",
 			}
 			expectedToleration := []*corev1.Toleration{
 				{
@@ -1279,7 +1282,9 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			pods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{LabelSelector: utils.SpireOIDCDiscoveryProviderPodLabel})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pods.Items).NotTo(BeEmpty())
-			utils.VerifyContainerResources(pods.Items, expectedResources)
+			activePods := utils.FilterActivePods(pods.Items)
+			Expect(activePods).NotTo(BeEmpty(), "no Running OIDC Discovery Provider pods found")
+			utils.VerifyContainerResources(activePods, expectedResources)
 		})
 
 		It("SPIRE OIDC Discovery Provider nodeSelector and tolerations can be configured through CR", func() {
@@ -1350,10 +1355,12 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			newPods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{LabelSelector: utils.SpireOIDCDiscoveryProviderPodLabel})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newPods.Items).NotTo(BeEmpty())
-			utils.VerifyPodScheduling(testCtx, clientset, newPods.Items, expectedNodeSelector)
+			runningPods := utils.FilterActivePods(newPods.Items)
+			Expect(runningPods).NotTo(BeEmpty(), "no Running OIDC Discovery Provider pods found")
+			utils.VerifyPodScheduling(testCtx, clientset, runningPods, expectedNodeSelector)
 
 			By("Verifying if SPIRE OIDC Discovery Provider Pods tolerate Node taints correctly")
-			utils.VerifyPodTolerations(testCtx, clientset, newPods.Items, expectedToleration)
+			utils.VerifyPodTolerations(testCtx, clientset, runningPods, expectedToleration)
 		})
 
 		It("SPIRE OIDC Discovery Provider affinity can be configured through CR", func() {
@@ -1650,9 +1657,10 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			utils.WaitForDeploymentAvailable(testCtx, clientset, utils.OperatorDeploymentName, utils.OperatorNamespace, utils.DefaultTimeout)
 
 			By("Waiting for CreateOnlyMode condition is False")
+			// Allow up to DefaultTimeout for the new operator pod to reconcile and update the ZTWM status in CI
 			utils.WaitForZeroTrustWorkloadIdentityManagerConditions(testCtx, k8sClient, "cluster", map[string]metav1.ConditionStatus{
 				"CreateOnlyMode": metav1.ConditionFalse,
-			}, utils.ShortTimeout)
+			}, utils.DefaultTimeout)
 
 			By("Verifying ConfigMap drift is corrected with CreateOnlyMode is False")
 			Eventually(func() bool {

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -116,6 +116,22 @@ func IsPodRunning(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning
 }
 
+// FilterActivePods returns only pods that are Running and not marked for deletion.
+// Use after a rolling update to exclude terminating or old ReplicaSet pods from verification.
+func FilterActivePods(pods []corev1.Pod) []corev1.Pod {
+	var active []corev1.Pod
+	for i := range pods {
+		p := &pods[i]
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		if IsPodRunning(p) {
+			active = append(active, pods[i])
+		}
+	}
+	return active
+}
+
 // IsPodReady checks if a pod has the Ready condition set to True
 func IsPodReady(pod *corev1.Pod) bool {
 	// Exclude the pod being terminated


### PR DESCRIPTION
This PR drops `shareProcessNamespace: true` from the `spire-server` pod so `spire-server` and `spire-controller-manager` no longer share a process namespace. They already communicate over the Unix socket in the shared volume; shared PID namespace is not required and weakens isolation (process visibility and signaling). 

The `ShareProcessNamespace` check in `StatefulSetNeedsUpdate` has been kept so existing clusters with the old spec still get an update and the change is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Process namespace is no longer shared among containers in the Spire Server StatefulSet, restoring container isolation.

* **Tests**
  * Unit tests updated to stop expecting a shared process namespace.
  * E2E tests hardened: use broader control-plane node label, validate only Running (non-terminating) pods, and increase suite timeout to 40 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->