### PR TITLE
SPIRE-439: SCC Hardening for Spire Agent

### DIFF
--- a/pkg/controller/spire-agent/controller.go
+++ b/pkg/controller/spire-agent/controller.go
@@ -98,7 +98,7 @@ func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if kerrors.IsNotFound(err) {
 			r.log.Error(err, "failed to get ZeroTrustWorkloadIdentityManager")
 			statusMgr.AddCondition(v1alpha1.Ready, v1alpha1.ReasonFailed,
-				fmt.Sprintf("Failed to retrieve ZeroTrustWorkloadIdentityManager from cluster"),
+				"Failed to retrieve ZeroTrustWorkloadIdentityManager from cluster",
 				metav1.ConditionFalse)
 			return ctrl.Result{}, nil
 		}

--- a/pkg/controller/spire-agent/daemonset.go
+++ b/pkg/controller/spire-agent/daemonset.go
@@ -175,8 +175,8 @@ func generateSpireAgentDaemonSet(config v1alpha1.SpireAgentSpec, ztwim *v1alpha1
 				},
 				Spec: corev1.PodSpec{
 					HostPID:            true,
-					HostNetwork:        true,
-					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+					HostNetwork:        false,
+					DNSPolicy:          corev1.DNSClusterFirst,
 					ServiceAccountName: "spire-agent",
 					Containers: []corev1.Container{
 						{
@@ -219,7 +219,14 @@ func generateSpireAgentDaemonSet(config v1alpha1.SpireAgentSpec, ztwim *v1alpha1
 							VolumeMounts: volumeMounts,
 							Resources:    utils.DerefResourceRequirements(config.Resources),
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: ptr.To(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								Privileged:               ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+								ReadOnlyRootFilesystem: ptr.To(true),
 							},
 						},
 					},

--- a/pkg/controller/spire-agent/daemonset_test.go
+++ b/pkg/controller/spire-agent/daemonset_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestGetHostCertMountPath(t *testing.T) {
@@ -155,4 +157,68 @@ func TestHostPathTypePtr(t *testing.T) {
 	result := hostPathTypePtr("DirectoryOrCreate")
 	assert.NotNil(t, result)
 	assert.Equal(t, "DirectoryOrCreate", string(*result))
+}
+
+// assertSpireAgentContainerHardening checks container securityContext matches
+// generateSpireAgentSCC: non-privileged, no escalation, cap drop ALL, R/O rootfs (see scc.go).
+func assertSpireAgentContainerHardening(t *testing.T, c *corev1.Container) {
+	t.Helper()
+	require.NotNil(t, c.SecurityContext, "spire-agent container must set securityContext for SCC hardening")
+	sc := c.SecurityContext
+	require.NotNil(t, sc.AllowPrivilegeEscalation, "allowPrivilegeEscalation must be explicit (false)")
+	assert.False(t, *sc.AllowPrivilegeEscalation, "AllowPrivilegeEscalation must be false to match spire-agent SCC")
+	require.NotNil(t, sc.Privileged, "privileged must be explicit (false)")
+	assert.False(t, *sc.Privileged, "container must not run privileged; matches AllowPrivilegedContainer: false in SCC")
+	require.NotNil(t, sc.ReadOnlyRootFilesystem, "readOnlyRootFilesystem must be explicit (true)")
+	assert.True(t, *sc.ReadOnlyRootFilesystem, "ReadOnlyRootFilesystem must be true; matches spire-agent SCC")
+	require.NotNil(t, sc.Capabilities, "capabilities must be set")
+	require.NotNil(t, sc.Capabilities.Drop, "must drop capabilities")
+	assert.Equal(t, []corev1.Capability{corev1.Capability("ALL")}, sc.Capabilities.Drop, "requiredDropCapabilities [ALL] in SCC")
+}
+
+func TestGenerateSpireAgentDaemonSet_SCCSecurityHardening(t *testing.T) {
+	ztwim := &v1alpha1.ZeroTrustWorkloadIdentityManager{
+		Spec: v1alpha1.ZeroTrustWorkloadIdentityManagerSpec{
+			TrustDomain:     "example.org",
+			BundleConfigMap: "spire-bundle",
+		},
+	}
+
+	t.Run("pod boundary matches spire-agent SCC (host PID, no host network/IPC/ports in SCC)", func(t *testing.T) {
+		spec := v1alpha1.SpireAgentSpec{
+			SocketPath: "/tmp/spire-agent/public",
+		}
+		ds := generateSpireAgentDaemonSet(spec, ztwim, "test-config-hash")
+		require.NotNil(t, ds)
+		pod := &ds.Spec.Template.Spec
+		assert.Equal(t, "spire-agent", pod.ServiceAccountName)
+		assert.True(t, pod.HostPID, "HostPID required for k8s workload attestation; SCC AllowHostPID: true")
+		assert.False(t, pod.HostNetwork, "HostNetwork disabled; SCC allowHostNetwork: false")
+		assert.Equal(t, corev1.DNSClusterFirst, pod.DNSPolicy)
+		require.Len(t, pod.Containers, 1)
+		assertSpireAgentContainerHardening(t, &pod.Containers[0])
+	})
+
+	t.Run("security context unchanged when kubelet CA hostPath is present", func(t *testing.T) {
+		spec := v1alpha1.SpireAgentSpec{
+			SocketPath: "/tmp/spire-agent/public",
+			WorkloadAttestors: &v1alpha1.WorkloadAttestors{
+				K8sEnabled: "true",
+				WorkloadAttestorsVerification: &v1alpha1.WorkloadAttestorsVerification{
+					Type: utils.WorkloadAttestorVerificationTypeAuto,
+				},
+			},
+		}
+		ds := generateSpireAgentDaemonSet(spec, ztwim, "hash")
+		var sawKubeletCA bool
+		for _, v := range ds.Spec.Template.Spec.Volumes {
+			if v.Name == "kubelet-ca" {
+				sawKubeletCA = true
+				break
+			}
+		}
+		require.True(t, sawKubeletCA, "expected kubelet-ca volume for auto verification / host cert")
+		require.Len(t, ds.Spec.Template.Spec.Containers, 1)
+		assertSpireAgentContainerHardening(t, &ds.Spec.Template.Spec.Containers[0])
+	})
 }

--- a/pkg/controller/spire-agent/scc.go
+++ b/pkg/controller/spire-agent/scc.go
@@ -26,7 +26,7 @@ func generateSpireAgentSCC(config *v1alpha1.SpireAgent) *securityv1.SecurityCont
 		},
 		ReadOnlyRootFilesystem: true,
 		RunAsUser: securityv1.RunAsUserStrategyOptions{
-			Type: securityv1.RunAsUserStrategyMustRunAsRange,
+			Type: securityv1.RunAsUserStrategyRunAsAny,
 		},
 		SELinuxContext: securityv1.SELinuxContextStrategyOptions{
 			Type: securityv1.SELinuxStrategyMustRunAs,
@@ -49,11 +49,11 @@ func generateSpireAgentSCC(config *v1alpha1.SpireAgent) *securityv1.SecurityCont
 		},
 		AllowHostDirVolumePlugin: true,
 		AllowHostIPC:             false,
-		AllowHostNetwork:         true,
+		AllowHostNetwork:         false,
 		AllowHostPID:             true,
-		AllowHostPorts:           true,
-		AllowPrivilegeEscalation: ptr.To(true),
-		AllowPrivilegedContainer: true,
+		AllowHostPorts:           false,
+		AllowPrivilegeEscalation: ptr.To(false),
+		AllowPrivilegedContainer: false,
 		AllowedCapabilities:      []corev1.Capability{},
 		DefaultAddCapabilities:   []corev1.Capability{},
 		RequiredDropCapabilities: []corev1.Capability{

--- a/pkg/controller/spire-agent/scc_test.go
+++ b/pkg/controller/spire-agent/scc_test.go
@@ -48,8 +48,8 @@ func TestGenerateSpireAgentSCC(t *testing.T) {
 		t.Errorf("expected ReadOnlyRootFilesystem to be true")
 	}
 
-	if scc.RunAsUser.Type != securityv1.RunAsUserStrategyMustRunAsRange {
-		t.Errorf("expected RunAsUser.Type to be MustRunAsRange")
+	if scc.RunAsUser.Type != securityv1.RunAsUserStrategyRunAsAny {
+		t.Errorf("expected RunAsUser.Type to be RunAsAny")
 	}
 
 	if scc.SELinuxContext.Type != securityv1.SELinuxStrategyMustRunAs {
@@ -86,20 +86,20 @@ func TestGenerateSpireAgentSCC(t *testing.T) {
 	if scc.AllowHostIPC {
 		t.Errorf("expected AllowHostIPC to be false")
 	}
-	if !scc.AllowHostNetwork {
-		t.Errorf("expected AllowHostNetwork to be true")
+	if scc.AllowHostNetwork {
+		t.Errorf("expected AllowHostNetwork to be false")
 	}
 	if !scc.AllowHostPID {
 		t.Errorf("expected AllowHostPID to be true")
 	}
-	if !scc.AllowHostPorts {
-		t.Errorf("expected AllowHostPorts to be true")
+	if scc.AllowHostPorts {
+		t.Errorf("expected AllowHostPorts to be false")
 	}
-	if scc.AllowPrivilegeEscalation == nil || !*scc.AllowPrivilegeEscalation {
-		t.Errorf("expected AllowPrivilegeEscalation to be true")
+	if scc.AllowPrivilegeEscalation == nil || *scc.AllowPrivilegeEscalation {
+		t.Errorf("expected AllowPrivilegeEscalation to be false")
 	}
-	if !scc.AllowPrivilegedContainer {
-		t.Errorf("expected AllowPrivilegedContainer to be true")
+	if scc.AllowPrivilegedContainer {
+		t.Errorf("expected AllowPrivilegedContainer to be false")
 	}
 
 	if len(scc.AllowedCapabilities) != 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened Spire Agent: disabled host networking, switched DNS policy to cluster-first, enforced read-only root filesystem, removed privileged mode, disabled privilege escalation, and dropped all Linux capabilities.
  * Tightened SecurityContextConstraints to restrict host access and privileged container execution.

* **Bug Fixes**
  * Minor message formatting change for a Ready/failure condition.

* **Tests**
  * Updated and added tests to validate the new security posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->