### PR TITLE
SPIRE-526: Remove "OpenShift Container Platform" from valid-subscription annotation in CSV

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -223,8 +223,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
-      Platform Plus"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.39.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/openshift/zero-trust-workload-identity-manager

--- a/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -17,8 +17,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: zero-trust-workload-identity-manager
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
-      Platform Plus"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Platform Plus"]'
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/openshift/zero-trust-workload-identity-manager
     support: Red Hat, Inc.


### PR DESCRIPTION
The operators.openshift.io/valid-subscription annotation incorrectly listed "OpenShift Container Platform" as a valid subscription. ZTWIM requires an OpenShift Platform Plus subscription.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported OpenShift subscription requirements. The operator now exclusively supports OpenShift Platform Plus subscriptions and no longer supports OpenShift Container Platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->