### PR TITLE
allow set_key_use through the SpireOIDCDiscoveryProvider CR

### DIFF
--- a/api/v1alpha1/spire_oidc_discovery_provider_types.go
+++ b/api/v1alpha1/spire_oidc_discovery_provider_types.go
@@ -62,6 +62,12 @@ type SpireOIDCDiscoveryProviderSpec struct {
 	// +kubebuilder:default:=1
 	ReplicaCount int `json:"replicaCount,omitempty"`
 
+	// setKeyUse controls whether the "use" parameter is set on the JWKS.
+	// When true, adds "use": "sig" to each key.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=false
+	SetKeyUse bool `json:"setKeyUse,omitempty"`
+
 	// managedRoute controls whether the operator automatically creates an OpenShift Route
 	// for the OIDC discovery provider endpoints.
 	// "true": The operator creates and maintains an OpenShift Route automatically for OIDC discovery endpoints (*.apps.).

--- a/config/crd/bases/operator.openshift.io_spireoidcdiscoveryproviders.yaml
+++ b/config/crd/bases/operator.openshift.io_spireoidcdiscoveryproviders.yaml
@@ -1100,6 +1100,12 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              setKeyUse:
+                default: false
+                description: |-
+                  setKeyUse controls whether the "use" parameter is set on the JWKS.
+                  When true, adds "use": "sig" to each key.
+                type: boolean
               tolerations:
                 description: |-
                   tolerations define the pod tolerations.

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps.go
@@ -119,6 +119,7 @@ func generateOIDCConfigMapFromCR(dp *v1alpha1.SpireOIDCDiscoveryProvider, ztwim 
 			"cert_file_path": "/etc/oidc/tls/tls.crt",
 			"key_file_path":  "/etc/oidc/tls/tls.key",
 		},
+		"set_key_use": dp.Spec.SetKeyUse,
 		"workload_api": map[string]string{
 			"socket_path":  "/spiffe-workload-api/" + agentSocketName,
 			"trust_domain": trustDomain,


### PR DESCRIPTION
Fixes https://github.com/openshift/zero-trust-workload-identity-manager/issues/108
- exposes `.spec.setKeyUse` in `SpireOIDCDiscoveryProvider` CR to pass `set_key_use` to the OIDC discovery provider config map. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `setKeyUse` configuration option to SpireOIDCDiscoveryProvider that allows enabling the `"use": "sig"` parameter on JWKS keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->