### PR TITLE
test/e2e: add focused SVID attestation coverage with shared helpers

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"time"
@@ -173,7 +174,7 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 				Spec: operatorv1alpha1.SpireServerSpec{
 					JwtIssuer:           jwtIssuer,
 					CAValidity:          metav1.Duration{Duration: 24 * time.Hour},
-					DefaultX509Validity: metav1.Duration{Duration: 1 * time.Hour},
+					DefaultX509Validity: metav1.Duration{Duration: utils.DefaultX509SVIDTTL},
 					DefaultJWTValidity:  metav1.Duration{Duration: 5 * time.Minute},
 					CASubject: operatorv1alpha1.CASubject{
 						CommonName:   appDomain,
@@ -397,62 +398,98 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 	})
 
 	Context("SpireAgent attestation", func() {
-		It("svid.pem should be a valid X.509 certificate", Label("reconciliation"), func() {
-			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-x509", nil)
+		Context("SVID validation", func() {
+			var f utils.AttestationFixture
 
-			By("Reading and parsing svid.pem")
-			_, block, rest, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
-			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+			BeforeAll(func() {
+				f = utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-validation", nil)
+			})
 
-			By("Validating PEM encoding")
-			Expect(block).NotTo(BeNil(), "svid.pem must contain a valid PEM block")
-			Expect(block.Type).To(Equal("CERTIFICATE"), "PEM block type must be CERTIFICATE")
-			Expect(rest).To(Satisfy(func(b []byte) bool {
-				trimmed := strings.TrimSpace(string(b))
-				if len(trimmed) == 0 {
-					return true
+			It("svid.pem should be a valid X.509 certificate", Label("attestation"), func() {
+				By("Reading and parsing svid.pem")
+				_, block, rest, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+				Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+
+				By("Validating PEM encoding")
+				Expect(block).NotTo(BeNil(), "svid.pem must contain a valid PEM block")
+				Expect(block.Type).To(Equal("CERTIFICATE"), "PEM block type must be CERTIFICATE")
+				Expect(rest).To(Satisfy(func(b []byte) bool {
+					trimmed := strings.TrimSpace(string(b))
+					if len(trimmed) == 0 {
+						return true
+					}
+					_, _, _, parseErr := utils.ParsePEMCertificate(trimmed)
+					return parseErr == nil
+				}), "remaining data after first PEM block must be empty or another valid PEM block")
+
+				By("Parsing X.509 certificate")
+				Expect(cert.NotBefore.Before(time.Now())).To(BeTrue(),
+					"certificate NotBefore (%s) must be in the past", cert.NotBefore)
+				Expect(cert.NotAfter.After(time.Now())).To(BeTrue(),
+					"certificate NotAfter (%s) must be in the future", cert.NotAfter)
+			})
+
+			It("SVID SPIFFE ID should match the expected value from ClusterSPIFFEID template", Label("attestation"), func() {
+				By("Reading and parsing svid.pem")
+				_, _, _, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+				Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+
+				By("Verifying SPIFFE ID in URI SAN")
+				expectedSPIFFEID := fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", appDomain, f.Namespace, f.SAName)
+				Expect(cert.URIs).NotTo(BeEmpty(), "certificate must contain at least one URI SAN")
+				Expect(cert.URIs[0].String()).To(Equal(expectedSPIFFEID),
+					"SVID SPIFFE ID must match expected value")
+			})
+
+			It("SVID expiry time should be within valid TTL bounds", Label("attestation"), func() {
+				By("Reading and parsing svid.pem")
+				_, _, _, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+				Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+
+				By("Verifying TTL is within valid bounds")
+				ttl := cert.NotAfter.Sub(cert.NotBefore)
+				fmt.Fprintf(GinkgoWriter, "SVID TTL: %s (NotBefore=%s, NotAfter=%s)\n", ttl, cert.NotBefore, cert.NotAfter)
+				Expect(ttl).To(BeNumerically(">", 0), "TTL must be positive")
+				Expect(ttl).To(BeNumerically("<=", utils.DefaultX509SVIDTTL),
+					"TTL must not exceed configured DefaultX509Validity (%s)", utils.DefaultX509SVIDTTL)
+				Expect(cert.NotAfter.After(time.Now())).To(BeTrue(), "certificate must not be expired")
+			})
+
+			It("bundle.pem should be a valid CA and svid.pem should chain to it", Label("attestation"), func() {
+				By("Reading and parsing bundle.pem")
+				bundlePEM, err := utils.ReadBundlePEM(testCtx, f.Namespace, f.PodName, f.AppContainer)
+				Expect(err).NotTo(HaveOccurred(), "failed to read bundle.pem from pod")
+
+				bundleCerts, err := utils.ParseAllPEMCertificates(bundlePEM)
+				Expect(err).NotTo(HaveOccurred(), "failed to parse bundle.pem certificates")
+				Expect(bundleCerts).NotTo(BeEmpty(), "bundle.pem must contain at least one certificate")
+
+				By("Verifying bundle certificates are CAs")
+				for i, ca := range bundleCerts {
+					Expect(ca.IsCA).To(BeTrue(), "bundle certificate [%d] must be a CA", i)
+					fmt.Fprintf(GinkgoWriter, "bundle cert [%d]: Subject=%s, IsCA=%v\n", i, ca.Subject, ca.IsCA)
 				}
-				_, _, _, parseErr := utils.ParsePEMCertificate(trimmed)
-				return parseErr == nil
-			}), "remaining data after first PEM block must be empty or another valid PEM block")
 
-			By("Parsing X.509 certificate")
-			Expect(cert.NotBefore.Before(time.Now())).To(BeTrue(),
-				"certificate NotBefore (%s) must be in the past", cert.NotBefore)
-			Expect(cert.NotAfter.After(time.Now())).To(BeTrue(),
-				"certificate NotAfter (%s) must be in the future", cert.NotAfter)
+				By("Building trust pool from bundle.pem")
+				rootPool := x509.NewCertPool()
+				for _, ca := range bundleCerts {
+					rootPool.AddCert(ca)
+				}
+
+				By("Reading and parsing svid.pem")
+				_, _, _, svidCert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+				Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+
+				By("Verifying svid.pem chains to bundle.pem")
+				_, err = svidCert.Verify(x509.VerifyOptions{
+					Roots:     rootPool,
+					KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+				})
+				Expect(err).NotTo(HaveOccurred(), "svid.pem must chain to bundle.pem")
+			})
 		})
 
-		It("SVID SPIFFE ID should match the expected value from ClusterSPIFFEID template", Label("reconciliation"), func() {
-			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "spiffeid-match", nil)
-
-			By("Reading and parsing svid.pem")
-			_, _, _, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
-			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
-
-			By("Verifying SPIFFE ID in URI SAN")
-			expectedSPIFFEID := fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", appDomain, f.Namespace, f.SAName)
-			Expect(cert.URIs).NotTo(BeEmpty(), "certificate must contain at least one URI SAN")
-			Expect(cert.URIs[0].String()).To(Equal(expectedSPIFFEID),
-				"SVID SPIFFE ID must match expected value")
-		})
-
-		It("SVID expiry time should be within valid TTL bounds", Label("reconciliation"), func() {
-			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-expiry", nil)
-
-			By("Reading and parsing svid.pem")
-			_, _, _, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
-			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
-
-			By("Verifying TTL is within valid bounds")
-			ttl := cert.NotAfter.Sub(cert.NotBefore)
-			fmt.Fprintf(GinkgoWriter, "SVID TTL: %s (NotBefore=%s, NotAfter=%s)\n", ttl, cert.NotBefore, cert.NotAfter)
-			Expect(ttl).To(BeNumerically(">", 0), "TTL must be positive")
-			Expect(ttl).To(BeNumerically("<=", 24*time.Hour), "TTL must not exceed 24 hours")
-			Expect(cert.NotAfter.After(time.Now())).To(BeTrue(), "certificate must not be expired")
-		})
-
-		It("SVID should be rotated before expiry", Label("reconciliation"), func() {
+		It("SVID should be rotated before expiry", Label("attestation"), func() {
 			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-rotation", func(spec *spiffev1alpha1.ClusterSPIFFEIDSpec) {
 				spec.TTL = metav1.Duration{Duration: 60 * time.Second}
 			})
@@ -464,20 +501,25 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			fmt.Fprintf(GinkgoWriter, "initial SVID serial: %s\n", initialSerial)
 
 			By("Waiting for SVID rotation (serial number change)")
+			var rotatedCert *x509.Certificate
 			Eventually(func() string {
 				_, _, _, c, parseErr := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
 				if parseErr != nil {
 					return initialSerial
 				}
+				rotatedCert = c
 				return c.SerialNumber.String()
 			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(Equal(initialSerial),
 				"SVID serial number must change after rotation")
 
 			By("Verifying rotated certificate is still valid")
-			_, _, _, rotatedCert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
-			Expect(err).NotTo(HaveOccurred(), "failed to read and parse rotated svid.pem from pod")
+			Expect(rotatedCert).NotTo(BeNil(), "rotated certificate must have been captured")
 			Expect(rotatedCert.NotBefore.Before(time.Now())).To(BeTrue(), "rotated cert NotBefore must be in the past")
 			Expect(rotatedCert.NotAfter.After(time.Now())).To(BeTrue(), "rotated cert NotAfter must be in the future")
+
+			By("Verifying rotated certificate is genuinely newer than the initial one")
+			Expect(rotatedCert.NotBefore.After(initialCert.NotBefore)).To(BeTrue(),
+				"rotated cert must have a later NotBefore than initial cert")
 			fmt.Fprintf(GinkgoWriter, "rotated SVID serial: %s\n", rotatedCert.SerialNumber.String())
 		})
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -398,161 +397,88 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 	})
 
 	Context("SpireAgent attestation", func() {
-		It("Workload attestation should succeed and workload receives SVID", func() {
-			attestationTestNamespace := "e2e-attestation-test"
-			attestationTestPodName := "attestation-test-pod"
-			attestationTestSA := "attestation-test-sa"
-			attestationTestAppContainer := "app"
+		It("svid.pem should be a valid X.509 certificate", Label("reconciliation"), func() {
+			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-x509", nil)
 
-			attestationNS := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: attestationTestNamespace,
-					Labels: map[string]string{
-						"kubernetes.io/metadata.name": attestationTestNamespace,
-					},
-				},
-			}
-			clusterSPIFFEID := &spiffev1alpha1.ClusterSPIFFEID{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "attestation-test",
-				},
-				Spec: spiffev1alpha1.ClusterSPIFFEIDSpec{
-					SPIFFEIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}",
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"app": "attestation-test"},
-					},
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"kubernetes.io/metadata.name": attestationTestNamespace,
-						},
-					},
-					ClassName: "zero-trust-workload-identity-manager-spire",
-				},
-			}
+			By("Reading and parsing svid.pem")
+			_, block, rest, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
 
-			By("Creating attestation test namespace")
-			err := k8sClient.Create(testCtx, attestationNS)
-			Expect(err).NotTo(HaveOccurred(), "failed to create attestation test namespace")
+			By("Validating PEM encoding")
+			Expect(block).NotTo(BeNil(), "svid.pem must contain a valid PEM block")
+			Expect(block.Type).To(Equal("CERTIFICATE"), "PEM block type must be CERTIFICATE")
+			Expect(rest).To(Satisfy(func(b []byte) bool {
+				trimmed := strings.TrimSpace(string(b))
+				if len(trimmed) == 0 {
+					return true
+				}
+				_, _, _, parseErr := utils.ParsePEMCertificate(trimmed)
+				return parseErr == nil
+			}), "remaining data after first PEM block must be empty or another valid PEM block")
 
-			By("Creating ClusterSPIFFEID for attestation test")
-			err = k8sClient.Create(testCtx, clusterSPIFFEID)
-			Expect(err).NotTo(HaveOccurred(), "failed to create ClusterSPIFFEID")
+			By("Parsing X.509 certificate")
+			Expect(cert.NotBefore.Before(time.Now())).To(BeTrue(),
+				"certificate NotBefore (%s) must be in the past", cert.NotBefore)
+			Expect(cert.NotAfter.After(time.Now())).To(BeTrue(),
+				"certificate NotAfter (%s) must be in the future", cert.NotAfter)
+		})
 
-			DeferCleanup(func(ctx context.Context) {
-				By("Deleting ClusterSPIFFEID")
-				_ = k8sClient.Delete(ctx, clusterSPIFFEID)
-				By("Deleting attestation test namespace")
-				_ = k8sClient.Delete(ctx, attestationNS)
+		It("SVID SPIFFE ID should match the expected value from ClusterSPIFFEID template", Label("reconciliation"), func() {
+			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "spiffeid-match", nil)
+
+			By("Reading and parsing svid.pem")
+			_, _, _, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+
+			By("Verifying SPIFFE ID in URI SAN")
+			expectedSPIFFEID := fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", appDomain, f.Namespace, f.SAName)
+			Expect(cert.URIs).NotTo(BeEmpty(), "certificate must contain at least one URI SAN")
+			Expect(cert.URIs[0].String()).To(Equal(expectedSPIFFEID),
+				"SVID SPIFFE ID must match expected value")
+		})
+
+		It("SVID expiry time should be within valid TTL bounds", Label("reconciliation"), func() {
+			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-expiry", nil)
+
+			By("Reading and parsing svid.pem")
+			_, _, _, cert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+
+			By("Verifying TTL is within valid bounds")
+			ttl := cert.NotAfter.Sub(cert.NotBefore)
+			fmt.Fprintf(GinkgoWriter, "SVID TTL: %s (NotBefore=%s, NotAfter=%s)\n", ttl, cert.NotBefore, cert.NotAfter)
+			Expect(ttl).To(BeNumerically(">", 0), "TTL must be positive")
+			Expect(ttl).To(BeNumerically("<=", 24*time.Hour), "TTL must not exceed 24 hours")
+			Expect(cert.NotAfter.After(time.Now())).To(BeTrue(), "certificate must not be expired")
+		})
+
+		It("SVID should be rotated before expiry", Label("reconciliation"), func() {
+			f := utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-rotation", func(spec *spiffev1alpha1.ClusterSPIFFEIDSpec) {
+				spec.TTL = metav1.Duration{Duration: 60 * time.Second}
 			})
 
-			By("Creating ServiceAccount")
-			sa := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      attestationTestSA,
-					Namespace: attestationTestNamespace,
-				},
-			}
-			err = k8sClient.Create(testCtx, sa)
-			Expect(err).NotTo(HaveOccurred(), "failed to create ServiceAccount")
+			By("Recording initial certificate serial number")
+			_, _, _, initialCert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+			Expect(err).NotTo(HaveOccurred(), "failed to read and parse svid.pem from pod")
+			initialSerial := initialCert.SerialNumber.String()
+			fmt.Fprintf(GinkgoWriter, "initial SVID serial: %s\n", initialSerial)
 
-			By("Creating spiffe-helper ConfigMap")
-			helperConf := utils.DefaultAttestationSpiffeHelperConfig().String()
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      utils.SpiffeHelperConfigMapName,
-					Namespace: attestationTestNamespace,
-				},
-				Data: map[string]string{
-					"helper.conf": helperConf,
-				},
-			}
-			err = k8sClient.Create(testCtx, cm)
-			Expect(err).NotTo(HaveOccurred(), "failed to create spiffe-helper ConfigMap")
-
-			By("Creating attestation test pod with CSI volume and spiffe-helper")
-			readOnlyTrue := true
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      attestationTestPodName,
-					Namespace: attestationTestNamespace,
-					Labels:    map[string]string{"app": "attestation-test"},
-				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: attestationTestSA,
-					Containers: []corev1.Container{
-						{
-							Name:  utils.SpiffeHelperContainerName,
-							Image: utils.SpiffeHelperImage,
-							Args:  []string{"-config", "/run/spiffe-helper/helper.conf"},
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "spiffe-workload-api", MountPath: "/spiffe-workload-api", ReadOnly: true},
-								{Name: "certs", MountPath: "/certs"},
-								{Name: "spiffe-helper-config", MountPath: "/run/spiffe-helper", ReadOnly: true},
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-								RunAsNonRoot:             ptr.To(true),
-								RunAsUser:                ptr.To(int64(1000)),
-								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-							},
-						},
-						{
-							Name:    attestationTestAppContainer,
-							Image:   "busybox",
-							Command: []string{"sleep", "3600"},
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "certs", MountPath: "/certs"},
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-								RunAsNonRoot:             ptr.To(true),
-								RunAsUser:                ptr.To(int64(1000)),
-								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "spiffe-workload-api",
-							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver:   "csi.spiffe.io",
-									ReadOnly: &readOnlyTrue,
-								},
-							},
-						},
-						{Name: "certs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-						{
-							Name: "spiffe-helper-config",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: utils.SpiffeHelperConfigMapName}},
-							},
-						},
-					},
-				},
-			}
-			err = k8sClient.Create(testCtx, pod)
-			Expect(err).NotTo(HaveOccurred(), "failed to create attestation test pod")
-
-			By("Waiting for attestation test pod to become ready")
-			utils.WaitForPodReady(testCtx, clientset, attestationTestPodName, attestationTestNamespace, 3*utils.ShortTimeout)
-
-			By("Verifying SVID files exist in /certs/")
+			By("Waiting for SVID rotation (serial number change)")
 			Eventually(func() string {
-				stdout, _, err := utils.ExecInPod(testCtx, attestationTestNamespace, attestationTestPodName, attestationTestAppContainer, []string{"ls", "/certs/"})
-				if err != nil {
-					fmt.Fprintf(GinkgoWriter, "exec ls /certs/ failed: %v\n", err)
-					return ""
+				_, _, _, c, parseErr := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+				if parseErr != nil {
+					return initialSerial
 				}
-				return stdout
-			}).WithTimeout(utils.DefaultTimeout).WithPolling(utils.DefaultInterval).Should(
-				And(
-					ContainSubstring("svid.pem"),
-					ContainSubstring("svid_key.pem"),
-					ContainSubstring("bundle.pem"),
-				))
+				return c.SerialNumber.String()
+			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).ShouldNot(Equal(initialSerial),
+				"SVID serial number must change after rotation")
+
+			By("Verifying rotated certificate is still valid")
+			_, _, _, rotatedCert, err := utils.ReadAndParseSVIDCertificate(testCtx, f.Namespace, f.PodName, f.AppContainer)
+			Expect(err).NotTo(HaveOccurred(), "failed to read and parse rotated svid.pem from pod")
+			Expect(rotatedCert.NotBefore.Before(time.Now())).To(BeTrue(), "rotated cert NotBefore must be in the past")
+			Expect(rotatedCert.NotAfter.After(time.Now())).To(BeTrue(), "rotated cert NotAfter must be in the future")
+			fmt.Fprintf(GinkgoWriter, "rotated SVID serial: %s\n", rotatedCert.SerialNumber.String())
 		})
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -450,8 +450,9 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 				ttl := cert.NotAfter.Sub(cert.NotBefore)
 				fmt.Fprintf(GinkgoWriter, "SVID TTL: %s (NotBefore=%s, NotAfter=%s)\n", ttl, cert.NotBefore, cert.NotAfter)
 				Expect(ttl).To(BeNumerically(">", 0), "TTL must be positive")
-				Expect(ttl).To(BeNumerically("<=", utils.DefaultX509SVIDTTL),
-					"TTL must not exceed configured DefaultX509Validity (%s)", utils.DefaultX509SVIDTTL)
+				Expect(ttl).To(BeNumerically("<=", utils.DefaultX509SVIDTTL+utils.ClockSkewTolerance),
+					"TTL must not exceed configured DefaultX509Validity (%s) plus clock skew tolerance (%s)",
+					utils.DefaultX509SVIDTTL, utils.ClockSkewTolerance)
 				Expect(cert.NotAfter.After(time.Now())).To(BeTrue(), "certificate must not be expired")
 			})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -402,7 +402,9 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			var f utils.AttestationFixture
 
 			BeforeAll(func() {
-				f = utils.SetupAttestationTest(testCtx, k8sClient, clientset, "svid-validation", nil)
+				setupCtx, cancel := context.WithTimeout(context.Background(), utils.TestContextTimeout)
+				DeferCleanup(cancel)
+				f = utils.SetupAttestationTest(setupCtx, k8sClient, clientset, "svid-validation", nil)
 			})
 
 			It("svid.pem should be a valid X.509 certificate", Label("attestation"), func() {

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -46,6 +46,9 @@ const (
 	SpiffeHelperImage         = "ghcr.io/spiffe/spiffe-helper:0.11.0"
 
 	DefaultX509SVIDTTL = 1 * time.Hour
+	// ClockSkewTolerance accounts for the small time buffer SPIRE adds to
+	// certificate validity for clock skew compensation.
+	ClockSkewTolerance = 1 * time.Minute
 
 	DefaultInterval    = 10 * time.Second
 	ShortInterval      = 5 * time.Second

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -45,6 +45,8 @@ const (
 	SpiffeHelperContainerName = "spiffe-helper"
 	SpiffeHelperImage         = "ghcr.io/spiffe/spiffe-helper:0.11.0"
 
+	DefaultX509SVIDTTL = 1 * time.Hour
+
 	DefaultInterval    = 10 * time.Second
 	ShortInterval      = 5 * time.Second
 	DefaultTimeout     = 5 * time.Minute

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -267,6 +267,44 @@ func ParsePEMCertificate(pemContent string) (*pem.Block, []byte, *x509.Certifica
 	return block, rest, cert, nil
 }
 
+// ReadBundlePEM reads /certs/bundle.pem from the given pod container.
+func ReadBundlePEM(ctx context.Context, namespace, podName, containerName string) (string, error) {
+	stdout, stderr, err := ExecInPod(ctx, namespace, podName, containerName, []string{"cat", "/certs/bundle.pem"})
+	if err != nil {
+		return "", fmt.Errorf("failed to read bundle.pem from pod (stderr: %s): %w", strings.TrimSpace(stderr), err)
+	}
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return "", fmt.Errorf("bundle.pem content must not be empty")
+	}
+	return stdout, nil
+}
+
+// ParseAllPEMCertificates parses all CERTIFICATE PEM blocks from pemContent.
+func ParseAllPEMCertificates(pemContent string) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	data := []byte(pemContent)
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no CERTIFICATE PEM blocks found")
+	}
+	return certs, nil
+}
+
 // ReadAndParseSVIDCertificate reads /certs/svid.pem from the pod and parses the first
 // certificate PEM block.
 func ReadAndParseSVIDCertificate(ctx context.Context, namespace, podName, containerName string) (string, *pem.Block, []byte, *x509.Certificate, error) {
@@ -960,8 +998,12 @@ func SetupAttestationTest(ctx context.Context, k8sClient client.Client, clientse
 	Expect(k8sClient.Create(ctx, cspiffeID)).To(Succeed(), "failed to create ClusterSPIFFEID")
 
 	DeferCleanup(func(cleanupCtx context.Context) {
-		_ = k8sClient.Delete(cleanupCtx, cspiffeID)
-		_ = k8sClient.Delete(cleanupCtx, attestationNS)
+		if err := k8sClient.Delete(cleanupCtx, cspiffeID); err != nil {
+			fmt.Fprintf(GinkgoWriter, "cleanup: failed to delete ClusterSPIFFEID %q: %v\n", cspiffeID.Name, err)
+		}
+		if err := k8sClient.Delete(cleanupCtx, attestationNS); err != nil {
+			fmt.Fprintf(GinkgoWriter, "cleanup: failed to delete namespace %q: %v\n", attestationNS.Name, err)
+		}
 	})
 
 	By("Creating ServiceAccount")

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -32,6 +34,8 @@ import (
 	operatorv1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 
+	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -43,6 +47,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -260,6 +265,50 @@ func ExecInPod(ctx context.Context, namespace, podName, containerName string, co
 		return stdoutBuf.String(), stderrBuf.String(), fmt.Errorf("exec %s %v: %w", cli, args, err)
 	}
 	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
+// ReadSVIDPEM reads /certs/svid.pem from the given pod container.
+func ReadSVIDPEM(ctx context.Context, namespace, podName, containerName string) (string, error) {
+	stdout, stderr, err := ExecInPod(ctx, namespace, podName, containerName, []string{"cat", "/certs/svid.pem"})
+	if err != nil {
+		return "", fmt.Errorf("failed to read svid.pem from pod (stderr: %s): %w", strings.TrimSpace(stderr), err)
+	}
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return "", fmt.Errorf("svid.pem content must not be empty")
+	}
+	return stdout, nil
+}
+
+// ParsePEMCertificate parses the first CERTIFICATE PEM block from pemContent and returns
+// the parsed certificate plus any remaining bytes.
+func ParsePEMCertificate(pemContent string) (*pem.Block, []byte, *x509.Certificate, error) {
+	block, rest := pem.Decode([]byte(pemContent))
+	if block == nil {
+		return nil, nil, nil, fmt.Errorf("content must contain a valid PEM block")
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, nil, nil, fmt.Errorf("PEM block type must be CERTIFICATE, got %q", block.Type)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("content must contain a valid X.509 certificate: %w", err)
+	}
+	return block, rest, cert, nil
+}
+
+// ReadAndParseSVIDCertificate reads /certs/svid.pem from the pod and parses the first
+// certificate PEM block.
+func ReadAndParseSVIDCertificate(ctx context.Context, namespace, podName, containerName string) (string, *pem.Block, []byte, *x509.Certificate, error) {
+	stdout, err := ReadSVIDPEM(ctx, namespace, podName, containerName)
+	if err != nil {
+		return "", nil, nil, nil, err
+	}
+	block, rest, cert, err := ParsePEMCertificate(stdout)
+	if err != nil {
+		return "", nil, nil, nil, err
+	}
+	return stdout, block, rest, cert, nil
 }
 
 // IsDeploymentAvailable checks if a Deployment has the Available condition set to True
@@ -860,4 +909,144 @@ func WaitForUpgradeableStatus(ctx context.Context, k8sClient client.Client, name
 		return true
 	}).WithTimeout(timeout).WithPolling(ShortInterval).Should(BeTrue(),
 		"Upgradeable condition should have status '%v' within %v", expectedStatus, timeout)
+}
+
+// AttestationFixture holds resource names for a self-contained attestation test environment.
+type AttestationFixture struct {
+	Namespace    string
+	PodName      string
+	SAName       string
+	AppContainer string
+}
+
+// SetupAttestationTest creates a complete attestation test environment (namespace, ClusterSPIFFEID,
+// ServiceAccount, spiffe-helper ConfigMap, pod with CSI volume) and waits until SVID files appear.
+// Each call produces an isolated environment; cleanup is registered via DeferCleanup.
+// Pass a non-nil cspiffeIDMutator to customise the ClusterSPIFFEID spec (e.g. set a short TTL).
+func SetupAttestationTest(ctx context.Context, k8sClient client.Client, clientset kubernetes.Interface, prefix string, cspiffeIDMutator func(*spiffev1alpha1.ClusterSPIFFEIDSpec)) AttestationFixture {
+	ns := fmt.Sprintf("e2e-%s-test", prefix)
+	podName := fmt.Sprintf("%s-test-pod", prefix)
+	saName := fmt.Sprintf("%s-test-sa", prefix)
+	appContainer := "app"
+
+	attestationNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   ns,
+			Labels: map[string]string{"kubernetes.io/metadata.name": ns},
+		},
+	}
+
+	spec := spiffev1alpha1.ClusterSPIFFEIDSpec{
+		SPIFFEIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}",
+		PodSelector:      &metav1.LabelSelector{MatchLabels: map[string]string{"app": prefix}},
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"kubernetes.io/metadata.name": ns},
+		},
+		ClassName: "zero-trust-workload-identity-manager-spire",
+	}
+	if cspiffeIDMutator != nil {
+		cspiffeIDMutator(&spec)
+	}
+
+	cspiffeID := &spiffev1alpha1.ClusterSPIFFEID{
+		ObjectMeta: metav1.ObjectMeta{Name: prefix + "-cspiffeid"},
+		Spec:       spec,
+	}
+
+	By("Creating attestation test namespace")
+	Expect(k8sClient.Create(ctx, attestationNS)).To(Succeed(), "failed to create namespace %s", ns)
+
+	By("Creating ClusterSPIFFEID")
+	Expect(k8sClient.Create(ctx, cspiffeID)).To(Succeed(), "failed to create ClusterSPIFFEID")
+
+	DeferCleanup(func(cleanupCtx context.Context) {
+		_ = k8sClient.Delete(cleanupCtx, cspiffeID)
+		_ = k8sClient.Delete(cleanupCtx, attestationNS)
+	})
+
+	By("Creating ServiceAccount")
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: ns}}
+	Expect(k8sClient.Create(ctx, sa)).To(Succeed(), "failed to create ServiceAccount")
+
+	By("Creating spiffe-helper ConfigMap")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: SpiffeHelperConfigMapName, Namespace: ns},
+		Data:       map[string]string{"helper.conf": DefaultAttestationSpiffeHelperConfig().String()},
+	}
+	Expect(k8sClient.Create(ctx, cm)).To(Succeed(), "failed to create spiffe-helper ConfigMap")
+
+	By("Creating attestation test pod with CSI volume and spiffe-helper")
+	readOnlyTrue := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName, Namespace: ns,
+			Labels: map[string]string{"app": prefix},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: saName,
+			Containers: []corev1.Container{
+				{
+					Name: SpiffeHelperContainerName, Image: SpiffeHelperImage,
+					Args: []string{"-config", "/run/spiffe-helper/helper.conf"},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "spiffe-workload-api", MountPath: "/spiffe-workload-api", ReadOnly: true},
+						{Name: "certs", MountPath: "/certs"},
+						{Name: "spiffe-helper-config", MountPath: "/run/spiffe-helper", ReadOnly: true},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             ptr.To(true),
+						RunAsUser:                ptr.To(int64(1000)),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+				},
+				{
+					Name: appContainer, Image: "busybox",
+					Command: []string{"sleep", "3600"},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "certs", MountPath: "/certs"},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             ptr.To(true),
+						RunAsUser:                ptr.To(int64(1000)),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "spiffe-workload-api", VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: "csi.spiffe.io", ReadOnly: &readOnlyTrue}}},
+				{Name: "certs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "spiffe-helper-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: SpiffeHelperConfigMapName}}}},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pod)).To(Succeed(), "failed to create attestation test pod")
+
+	By("Waiting for attestation test pod to become ready")
+	WaitForPodReady(ctx, clientset, podName, ns, 3*ShortTimeout)
+
+	By("Waiting for SVID files to appear in /certs/")
+	Eventually(func() string {
+		stdout, _, err := ExecInPod(ctx, ns, podName, appContainer, []string{"ls", "/certs/"})
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "exec ls /certs/ failed: %v\n", err)
+			return ""
+		}
+		return stdout
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultInterval).Should(
+		And(
+			ContainSubstring("svid.pem"),
+			ContainSubstring("svid_key.pem"),
+			ContainSubstring("bundle.pem"),
+		))
+
+	return AttestationFixture{
+		Namespace:    ns,
+		PodName:      podName,
+		SAName:       saName,
+		AppContainer: appContainer,
+	}
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"encoding/pem"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,36 +50,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// SpiffeHelperConfig holds configuration for the spiffe-helper sidecar (helper.conf format).
-type SpiffeHelperConfig struct {
-	AgentAddress       string
-	CertDir            string
-	SvidFileName       string
-	SvidKeyFileName    string
-	SvidBundleFileName string
-}
-
-// DefaultAttestationSpiffeHelperConfig returns the default config for E2E attestation tests.
-func DefaultAttestationSpiffeHelperConfig() SpiffeHelperConfig {
-	return SpiffeHelperConfig{
-		AgentAddress:       "/spiffe-workload-api/spire-agent.sock",
-		CertDir:            "/certs",
-		SvidFileName:       "svid.pem",
-		SvidKeyFileName:    "svid_key.pem",
-		SvidBundleFileName: "bundle.pem",
-	}
-}
-
-// String returns the config as a TOML-like string for helper.conf.
-func (c SpiffeHelperConfig) String() string {
-	return fmt.Sprintf(`agent_address = %q
-cert_dir = %q
-svid_file_name = %q
-svid_key_file_name = %q
-svid_bundle_file_name = %q
-`, c.AgentAddress, c.CertDir, c.SvidFileName, c.SvidKeyFileName, c.SvidBundleFileName)
-}
 
 // GetTestDir returns the directory to write test results to
 func GetTestDir() string {
@@ -909,6 +879,36 @@ func WaitForUpgradeableStatus(ctx context.Context, k8sClient client.Client, name
 		return true
 	}).WithTimeout(timeout).WithPolling(ShortInterval).Should(BeTrue(),
 		"Upgradeable condition should have status '%v' within %v", expectedStatus, timeout)
+}
+
+// SpiffeHelperConfig holds configuration for the spiffe-helper sidecar (helper.conf format).
+type SpiffeHelperConfig struct {
+	AgentAddress       string
+	CertDir            string
+	SvidFileName       string
+	SvidKeyFileName    string
+	SvidBundleFileName string
+}
+
+// DefaultAttestationSpiffeHelperConfig returns the default config for E2E attestation tests.
+func DefaultAttestationSpiffeHelperConfig() SpiffeHelperConfig {
+	return SpiffeHelperConfig{
+		AgentAddress:       "/spiffe-workload-api/spire-agent.sock",
+		CertDir:            "/certs",
+		SvidFileName:       "svid.pem",
+		SvidKeyFileName:    "svid_key.pem",
+		SvidBundleFileName: "bundle.pem",
+	}
+}
+
+// String returns the config as a TOML-like string for helper.conf.
+func (c SpiffeHelperConfig) String() string {
+	return fmt.Sprintf(`agent_address = %q
+cert_dir = %q
+svid_file_name = %q
+svid_key_file_name = %q
+svid_bundle_file_name = %q
+`, c.AgentAddress, c.CertDir, c.SvidFileName, c.SvidKeyFileName, c.SvidBundleFileName)
 }
 
 // AttestationFixture holds resource names for a self-contained attestation test environment.

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -19,7 +19,9 @@ package utils
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -962,9 +964,12 @@ type AttestationFixture struct {
 // Each call produces an isolated environment; cleanup is registered via DeferCleanup.
 // Pass a non-nil cspiffeIDMutator to customise the ClusterSPIFFEID spec (e.g. set a short TTL).
 func SetupAttestationTest(ctx context.Context, k8sClient client.Client, clientset kubernetes.Interface, prefix string, cspiffeIDMutator func(*spiffev1alpha1.ClusterSPIFFEIDSpec)) AttestationFixture {
-	ns := fmt.Sprintf("e2e-%s-test", prefix)
-	podName := fmt.Sprintf("%s-test-pod", prefix)
-	saName := fmt.Sprintf("%s-test-sa", prefix)
+	randBytes := make([]byte, 3)
+	_, _ = rand.Read(randBytes)
+	suffix := hex.EncodeToString(randBytes)
+	ns := fmt.Sprintf("e2e-%s-test-%s", prefix, suffix)
+	podName := fmt.Sprintf("%s-test-pod-%s", prefix, suffix)
+	saName := fmt.Sprintf("%s-test-sa-%s", prefix, suffix)
 	appContainer := "app"
 
 	attestationNS := &corev1.Namespace{
@@ -987,7 +992,7 @@ func SetupAttestationTest(ctx context.Context, k8sClient client.Client, clientse
 	}
 
 	cspiffeID := &spiffev1alpha1.ClusterSPIFFEID{
-		ObjectMeta: metav1.ObjectMeta{Name: prefix + "-cspiffeid"},
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-cspiffeid-%s", prefix, suffix)},
 		Spec:       spec,
 	}
 


### PR DESCRIPTION
1. Move attestation test setup into reusable helper functions in utils.
2. Add clear checks for:
3. valid svid.pem X.509 certificate
4. correct SPIFFE ID in certificate
5. valid certificate expiry window
6. SVID rotation using short TTL
7. Remove repeated setup and cert parsing code.
8. Make attestation E2E tests easier to read and maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded attestation e2e coverage with validations for SVID X.509 PEM/certificate contents, SPIFFE ID matching, TTL bounds/non-expiration, CA chaining, and rotation before expiry.
  * Added fixture-based attestation setup and utilities to provision isolated test pods and retrieve/parse SVID and bundle PEMs.
  * Introduced a default X.509 SVID TTL used by the e2e suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->