### PR TITLE
OAPE-694: Add E2E coverage setup and collection script

### DIFF
--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
 
 FROM registry.access.redhat.com/ubi9-minimal:9.4
 WORKDIR /
+RUN microdnf install -y tar && microdnf clean all
 COPY --from=builder /workspace/zero-trust-workload-identity-manager /usr/bin
 RUN mkdir -p /tmp/e2e-cover && chown 65532:65532 /tmp/e2e-cover && chmod 700 /tmp/e2e-cover
 USER 65532:65532

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
 FROM registry.access.redhat.com/ubi9-minimal:9.4
 WORKDIR /
 COPY --from=builder /workspace/zero-trust-workload-identity-manager /usr/bin
-RUN mkdir -p /tmp/e2e-cover && chmod 777 /tmp/e2e-cover
+RUN mkdir -p /tmp/e2e-cover && chown 65532:65532 /tmp/e2e-cover && chmod 700 /tmp/e2e-cover
 USER 65532:65532
 ENV GOCOVERDIR=/tmp/e2e-cover
 ENTRYPOINT ["/usr/bin/zero-trust-workload-identity-manager"]

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -1,0 +1,24 @@
+# Build the Zero Trust Workload Identity Manager binary with coverage instrumentation.
+# This mirrors the production Dockerfile but adds Go coverage flags so the binary
+# records which lines are executed during E2E tests.
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY . .
+RUN go mod download
+
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -mod=mod -a \
+    -cover -covermode=count -coverpkg=./... \
+    -o zero-trust-workload-identity-manager \
+    ./cmd/zero-trust-workload-identity-manager/main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:9.4
+WORKDIR /
+COPY --from=builder /workspace/zero-trust-workload-identity-manager /usr/bin
+RUN mkdir -p /tmp/e2e-cover && chmod 777 /tmp/e2e-cover
+USER 65532:65532
+ENV GOCOVERDIR=/tmp/e2e-cover
+ENTRYPOINT ["/usr/bin/zero-trust-workload-identity-manager"]

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -6,8 +6,9 @@ ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
-COPY . .
+COPY go.mod go.sum ./
 RUN go mod download
+COPY . .
 
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -mod=mod -a \

--- a/Makefile
+++ b/Makefile
@@ -352,12 +352,14 @@ vendor:
 ##
 ## Targets for building a coverage-instrumented operator image, collecting
 ## coverage data written during E2E tests, and uploading the report to Codecov.
+## Uses emptyDir (no PVC): the collect step sends SIGTERM to the operator
+## process, waits for container restart, then copies data from the running pod.
 ##
 ## Typical flow (local):
 ##   make docker-build-coverage docker-push-coverage   # build & push coverage image
-##   <deploy coverage image to cluster via CSV patch>
+##   COVERAGE_IMAGE=<pullspec> hack/e2e-coverage.sh setup  # patch CSV
 ##   make test-e2e                                      # run E2E suite
-##   make e2e-coverage-collect KUBECTL=oc               # collect + upload
+##   make e2e-coverage-collect                           # collect + upload
 ##
 ## In CI, hack/e2e-coverage.sh handles setup and collection automatically.
 

--- a/Makefile
+++ b/Makefile
@@ -347,3 +347,30 @@ verify: vet fmt golangci-lint
 vendor:
 	go mod tidy
 	go mod vendor
+
+##@ E2E Coverage
+##
+## Targets for building a coverage-instrumented operator image, collecting
+## coverage data written during E2E tests, and uploading the report to Codecov.
+##
+## Typical flow (local):
+##   make docker-build-coverage docker-push-coverage   # build & push coverage image
+##   <deploy coverage image to cluster via CSV patch>
+##   make test-e2e                                      # run E2E suite
+##   make e2e-coverage-collect KUBECTL=oc               # collect + upload
+##
+## In CI, hack/e2e-coverage.sh handles setup and collection automatically.
+
+COVERAGE_IMG ?= $(IMG)-e2e-coverage
+
+.PHONY: docker-build-coverage
+docker-build-coverage: ## Build coverage Docker image from Dockerfile.coverage.
+	$(CONTAINER_TOOL) build -f Dockerfile.coverage -t $(COVERAGE_IMG) .
+
+.PHONY: docker-push-coverage
+docker-push-coverage: ## Push coverage Docker image.
+	$(CONTAINER_TOOL) push $(COVERAGE_IMG)
+
+.PHONY: e2e-coverage-collect
+e2e-coverage-collect: ## Collect e2e coverage data and optionally upload to Codecov.
+	ARTIFACT_DIR=$${ARTIFACT_DIR:-.} hack/e2e-coverage.sh collect

--- a/Makefile
+++ b/Makefile
@@ -352,8 +352,6 @@ vendor:
 ##
 ## Targets for building a coverage-instrumented operator image, collecting
 ## coverage data written during E2E tests, and uploading the report to Codecov.
-## Uses emptyDir (no PVC): the collect step sends SIGTERM to the operator
-## process, waits for container restart, then copies data from the running pod.
 ##
 ## Typical flow (local):
 ##   make docker-build-coverage docker-push-coverage   # build & push coverage image

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -22,7 +22,7 @@ setup() {
     echo "--- E2E Coverage Setup ---"
 
     if [[ -z "${COVERAGE_IMAGE:-}" ]]; then
-        echo "Error: COVERAGE_IMAGE env var must be set"
+        echo "Error: COVERAGE_IMAGE env var must be set" >&2
         exit 1
     fi
     echo "Coverage image: ${COVERAGE_IMAGE}"
@@ -32,10 +32,10 @@ setup() {
     csv=$(oc get deployment "${DEPLOYMENT}" -n "${NAMESPACE}" \
         -o jsonpath='{.metadata.ownerReferences[?(@.kind=="ClusterServiceVersion")].name}')
     if [[ -z "${csv}" ]]; then
-        echo "Error: no CSV found for zero-trust-workload-identity-manager"
+        echo "Error: no CSV entry found in ownerReference for ${DEPLOYMENT} in namespace ${NAMESPACE}" >&2
         exit 1
     fi
-    echo "Found CSV: ${csv}"
+    echo "CSV name derived from deployment ownerReferences to patch: ${csv}"
 
     echo "Patching CSV with coverage image, GOCOVERDIR, and emptyDir volume..."
     oc patch csv "${csv}" -n "${NAMESPACE}" --type=json -p "[
@@ -71,7 +71,7 @@ collect() {
     pod=$(oc get pod -n "${NAMESPACE}" -l "${POD_LABEL}" \
         -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
     if [[ -z "${pod}" ]]; then
-        echo "Error: no operator pod found in namespace ${NAMESPACE}"
+        echo "Error: no operator pod found in namespace ${NAMESPACE}" >&2
         exit 1
     fi
     echo "Operator pod: ${pod}"
@@ -144,7 +144,11 @@ collect() {
                 echo "Local run -- no Prow context, Codecov will auto-detect from git"
             fi
 
-            "${codecov_bin}" "${codecov_args[@]}" || echo "Warning: Codecov upload failed (non-fatal)"
+            local rc=0
+            "${codecov_bin}" "${codecov_args[@]}" || rc=$?
+            if [[ ${rc} -ne 0 ]]; then
+                echo "Warning: Codecov upload failed with exit code ${rc} (non-fatal)" >&2
+            fi
             rm -f "${codecov_bin}" "${codecov_bin}.SHA256SUM" "${codecov_bin}.SHA256SUM.sig"
         else
             echo "CODECOV_TOKEN not set -- skipping Codecov upload."

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -46,7 +46,6 @@ setup() {
     ]"
 
     echo "Waiting for operator rollout with coverage image..."
-    sleep 5
     oc rollout status "deployment/${DEPLOYMENT}" -n "${NAMESPACE}" --timeout=180s
 
     echo "Verifying GOCOVERDIR is set in the running pod..."
@@ -81,7 +80,7 @@ collect() {
     oc exec -n "${NAMESPACE}" "${pod}" -c manager -- /bin/sh -c 'kill -TERM 1' || true
 
     echo "Waiting for container to restart..."
-    sleep 10
+    oc wait pod/"${pod}" --for=condition=Ready=False -n "${NAMESPACE}" --timeout=30s 2>/dev/null || true
     oc wait pod/"${pod}" --for=condition=Ready -n "${NAMESPACE}" --timeout=120s
 
     mkdir -p "${coverage_dir}"
@@ -104,10 +103,11 @@ collect() {
 
         if [[ -n "${CODECOV_TOKEN:-}" ]]; then
             echo "Uploading to Codecov..."
+            local codecov_version="v0.8.0"
             local codecov_bin="${artifact_dir}/codecov"
-            curl -sS -o "${codecov_bin}"              https://uploader.codecov.io/latest/linux/codecov
-            curl -sS -o "${codecov_bin}.SHA256SUM"    https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -sS -o "${codecov_bin}.SHA256SUM.sig" https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -sS -o "${codecov_bin}"              "https://uploader.codecov.io/${codecov_version}/linux/codecov"
+            curl -sS -o "${codecov_bin}.SHA256SUM"    "https://uploader.codecov.io/${codecov_version}/linux/codecov.SHA256SUM"
+            curl -sS -o "${codecov_bin}.SHA256SUM.sig" "https://uploader.codecov.io/${codecov_version}/linux/codecov.SHA256SUM.sig"
 
             if command -v gpg >/dev/null 2>&1 && command -v gpgv >/dev/null 2>&1; then
                 curl -sS https://keybase.io/codecovsecurity/pgp_keys.asc \

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# E2E coverage lifecycle script for CI and local use.
+#
+# Usage:
+#   hack/e2e-coverage.sh setup    Prepare the operator for coverage collection
+#   hack/e2e-coverage.sh collect  Collect, convert, and optionally upload coverage data
+#
+# Environment variables:
+#   COVERAGE_IMAGE          (setup)   Full pullspec of the coverage-instrumented image
+#   CODECOV_TOKEN           (collect) Codecov upload token; skip upload if unset
+#   ARTIFACT_DIR            (collect) Directory for CI artifacts; defaults to "."
+#   COVERAGE_EXTRACTOR_IMAGE          Image used to extract data from PVC; default golang:1.25
+set -euo pipefail
+
+NAMESPACE="zero-trust-workload-identity-manager"
+DEPLOYMENT="zero-trust-workload-identity-manager-controller-manager"
+PVC_NAME="e2e-coverage-pvc"
+GOCOVERDIR_PATH="/tmp/e2e-cover"
+EXTRACTOR_IMAGE="${COVERAGE_EXTRACTOR_IMAGE:-golang:1.25}"
+CODECOV_SECRET_PATH="/var/run/secrets/codecov/CODECOV_TOKEN"
+
+setup() {
+    echo "--- E2E Coverage Setup ---"
+
+    if [[ -z "${COVERAGE_IMAGE:-}" ]]; then
+        echo "Error: COVERAGE_IMAGE env var must be set"
+        exit 1
+    fi
+    echo "Coverage image: ${COVERAGE_IMAGE}"
+
+    echo "Creating PVC for coverage data..."
+    oc apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+
+    echo "Discovering CSV..."
+    local csv
+    csv=$(oc get csv -n "${NAMESPACE}" -o name \
+        | grep zero-trust-workload-identity-manager \
+        | head -1 \
+        | sed 's|^clusterserviceversion.operators.coreos.com/||')
+    if [[ -z "${csv}" ]]; then
+        echo "Error: no CSV found for zero-trust-workload-identity-manager"
+        exit 1
+    fi
+    echo "Found CSV: ${csv}"
+
+    echo "Patching CSV with coverage image, GOCOVERDIR, and PVC volume..."
+    oc patch csv "${csv}" -n "${NAMESPACE}" --type=json -p "[
+        {\"op\": \"replace\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/image\", \"value\": \"${COVERAGE_IMAGE}\"},
+        {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-\", \"value\": {\"name\": \"GOCOVERDIR\", \"value\": \"${GOCOVERDIR_PATH}\"}},
+        {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/volumeMounts/-\", \"value\": {\"name\": \"coverage-data\", \"mountPath\": \"${GOCOVERDIR_PATH}\"}},
+        {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/volumes/-\", \"value\": {\"name\": \"coverage-data\", \"persistentVolumeClaim\": {\"claimName\": \"${PVC_NAME}\"}}}
+    ]"
+
+    echo "Waiting for operator rollout with coverage image..."
+    sleep 5
+    oc rollout status "deployment/${DEPLOYMENT}" -n "${NAMESPACE}" --timeout=180s
+
+    echo "Verifying GOCOVERDIR is set in the running pod..."
+    oc exec -n "${NAMESPACE}" "deploy/${DEPLOYMENT}" -- env | grep GOCOVERDIR || \
+        echo "Warning: GOCOVERDIR not found in pod env (non-fatal)"
+
+    echo "--- Coverage setup complete ---"
+}
+
+collect() {
+    echo "--- E2E Coverage Collection ---"
+
+    local artifact_dir="${ARTIFACT_DIR:-.}"
+    local coverage_dir="${artifact_dir}/e2e-cover-data"
+    local coverage_profile="${artifact_dir}/coverage-e2e.out"
+
+    # Read Codecov token from mounted secret if available
+    if [[ -z "${CODECOV_TOKEN:-}" ]] && [[ -f "${CODECOV_SECRET_PATH}" ]]; then
+        CODECOV_TOKEN=$(cat "${CODECOV_SECRET_PATH}")
+        export CODECOV_TOKEN
+    fi
+
+    echo "Scaling down operator to flush coverage data via SIGTERM..."
+    oc scale "deployment/${DEPLOYMENT}" --replicas=0 -n "${NAMESPACE}" || true
+    oc wait --for=delete pod -l name=zero-trust-workload-identity-manager \
+        -n "${NAMESPACE}" --timeout=60s 2>/dev/null || true
+
+    echo "Creating extractor pod to access PVC data..."
+    oc run coverage-extractor \
+        --image="${EXTRACTOR_IMAGE}" \
+        --restart=Never \
+        --overrides="{
+            \"spec\": {
+                \"volumes\": [{\"name\": \"cov\", \"persistentVolumeClaim\": {\"claimName\": \"${PVC_NAME}\"}}],
+                \"containers\": [{\"name\": \"coverage-extractor\", \"image\": \"${EXTRACTOR_IMAGE}\",
+                    \"command\": [\"sleep\", \"600\"],
+                    \"volumeMounts\": [{\"name\": \"cov\", \"mountPath\": \"${GOCOVERDIR_PATH}\"}]
+                }]
+            }
+        }" \
+        -n "${NAMESPACE}"
+
+    oc wait pod/coverage-extractor --for=condition=Ready \
+        -n "${NAMESPACE}" --timeout=120s
+
+    mkdir -p "${coverage_dir}"
+    oc cp "${NAMESPACE}/coverage-extractor:${GOCOVERDIR_PATH}" "${coverage_dir}"
+    oc delete pod coverage-extractor -n "${NAMESPACE}" --wait=false || true
+
+    echo "Coverage files:"
+    ls -la "${coverage_dir}/" 2>/dev/null || true
+
+    if ls "${coverage_dir}"/covmeta.* >/dev/null 2>&1; then
+        echo "Converting coverage data to Go profile format..."
+        go tool covdata textfmt -i="${coverage_dir}" -o="${coverage_profile}"
+
+        echo ""
+        echo "=== E2E Coverage Summary ==="
+        go tool covdata percent -i="${coverage_dir}"
+        echo "============================="
+        echo ""
+        echo "Coverage profile: ${coverage_profile} ($(wc -l < "${coverage_profile}") lines)"
+
+        if [[ -n "${CODECOV_TOKEN:-}" ]]; then
+            echo "Uploading to Codecov..."
+            local codecov_bin="${artifact_dir}/codecov"
+            curl -sS -o "${codecov_bin}" https://uploader.codecov.io/latest/linux/codecov
+            chmod +x "${codecov_bin}"
+            "${codecov_bin}" \
+                --file="${coverage_profile}" \
+                --flags=e2e \
+                --name="E2E Coverage" \
+                --token="${CODECOV_TOKEN}" \
+                --verbose || echo "Warning: Codecov upload failed (non-fatal)"
+            rm -f "${codecov_bin}"
+        else
+            echo "CODECOV_TOKEN not set -- skipping Codecov upload."
+            echo "Coverage profile saved as artifact: ${coverage_profile}"
+        fi
+    else
+        echo "Warning: No coverage data found in ${coverage_dir}"
+        echo "The operator may not have been built with coverage instrumentation,"
+        echo "or it may not have exited cleanly (SIGKILL instead of SIGTERM)."
+    fi
+
+    echo "--- Coverage collection complete ---"
+}
+
+case "${1:-}" in
+    setup)
+        setup
+        ;;
+    collect)
+        collect
+        ;;
+    *)
+        echo "Usage: $0 {setup|collect}" >&2
+        exit 1
+        ;;
+esac

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -10,14 +10,12 @@
 #   COVERAGE_IMAGE          (setup)   Full pullspec of the coverage-instrumented image
 #   CODECOV_TOKEN           (collect) Codecov upload token; skip upload if unset
 #   ARTIFACT_DIR            (collect) Directory for CI artifacts; defaults to "."
-#   COVERAGE_EXTRACTOR_IMAGE          Image used to extract data from PVC; default golang:1.25
 set -euo pipefail
 
 NAMESPACE="zero-trust-workload-identity-manager"
 DEPLOYMENT="zero-trust-workload-identity-manager-controller-manager"
-PVC_NAME="e2e-coverage-pvc"
+POD_LABEL="name=zero-trust-workload-identity-manager"
 GOCOVERDIR_PATH="/tmp/e2e-cover"
-EXTRACTOR_IMAGE="${COVERAGE_EXTRACTOR_IMAGE:-golang:1.25}"
 CODECOV_SECRET_PATH="/var/run/secrets/codecov/CODECOV_TOKEN"
 
 setup() {
@@ -29,21 +27,6 @@ setup() {
     fi
     echo "Coverage image: ${COVERAGE_IMAGE}"
 
-    echo "Creating PVC for coverage data..."
-    oc apply -f - <<EOF
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: ${PVC_NAME}
-  namespace: ${NAMESPACE}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-EOF
-
     echo "Discovering CSV from deployment ownerReference..."
     local csv
     csv=$(oc get deployment "${DEPLOYMENT}" -n "${NAMESPACE}" \
@@ -54,12 +37,12 @@ EOF
     fi
     echo "Found CSV: ${csv}"
 
-    echo "Patching CSV with coverage image, GOCOVERDIR, and PVC volume..."
+    echo "Patching CSV with coverage image, GOCOVERDIR, and emptyDir volume..."
     oc patch csv "${csv}" -n "${NAMESPACE}" --type=json -p "[
         {\"op\": \"replace\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/image\", \"value\": \"${COVERAGE_IMAGE}\"},
         {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-\", \"value\": {\"name\": \"GOCOVERDIR\", \"value\": \"${GOCOVERDIR_PATH}\"}},
         {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/volumeMounts/-\", \"value\": {\"name\": \"coverage-data\", \"mountPath\": \"${GOCOVERDIR_PATH}\"}},
-        {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/volumes/-\", \"value\": {\"name\": \"coverage-data\", \"persistentVolumeClaim\": {\"claimName\": \"${PVC_NAME}\"}}}
+        {\"op\": \"add\", \"path\": \"/spec/install/spec/deployments/0/spec/template/spec/volumes/-\", \"value\": {\"name\": \"coverage-data\", \"emptyDir\": {}}}
     ]"
 
     echo "Waiting for operator rollout with coverage image..."
@@ -80,41 +63,30 @@ collect() {
     local coverage_dir="${artifact_dir}/e2e-cover-data"
     local coverage_profile="${artifact_dir}/coverage-e2e.out"
 
-    # Read Codecov token from mounted secret if available
     if [[ -z "${CODECOV_TOKEN:-}" ]] && [[ -f "${CODECOV_SECRET_PATH}" ]]; then
         CODECOV_TOKEN=$(cat "${CODECOV_SECRET_PATH}")
         export CODECOV_TOKEN
     fi
 
-    echo "Scaling down operator to flush coverage data via SIGTERM..."
-    oc scale "deployment/${DEPLOYMENT}" --replicas=0 -n "${NAMESPACE}" || true
-    oc wait --for=delete pod -l name=zero-trust-workload-identity-manager \
-        -n "${NAMESPACE}" --timeout=60s 2>/dev/null || true
+    local pod
+    pod=$(oc get pod -n "${NAMESPACE}" -l "${POD_LABEL}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    if [[ -z "${pod}" ]]; then
+        echo "Error: no operator pod found in namespace ${NAMESPACE}"
+        exit 1
+    fi
+    echo "Operator pod: ${pod}"
 
-    # Clean up any leftover extractor pod from a prior run
-    oc delete pod coverage-extractor -n "${NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true
+    echo "Sending SIGTERM to operator process to flush coverage data..."
+    oc exec -n "${NAMESPACE}" "${pod}" -c manager -- /bin/sh -c 'kill -TERM 1' || true
 
-    echo "Creating extractor pod to access PVC data..."
-    oc run coverage-extractor \
-        --image="${EXTRACTOR_IMAGE}" \
-        --restart=Never \
-        --overrides="{
-            \"spec\": {
-                \"volumes\": [{\"name\": \"cov\", \"persistentVolumeClaim\": {\"claimName\": \"${PVC_NAME}\"}}],
-                \"containers\": [{\"name\": \"coverage-extractor\", \"image\": \"${EXTRACTOR_IMAGE}\",
-                    \"command\": [\"sleep\", \"600\"],
-                    \"volumeMounts\": [{\"name\": \"cov\", \"mountPath\": \"${GOCOVERDIR_PATH}\"}]
-                }]
-            }
-        }" \
-        -n "${NAMESPACE}"
+    echo "Waiting for container to restart..."
+    sleep 10
+    oc wait pod/"${pod}" --for=condition=Ready -n "${NAMESPACE}" --timeout=120s
 
-    oc wait pod/coverage-extractor --for=condition=Ready \
-        -n "${NAMESPACE}" --timeout=120s
-
-    # Use /. suffix so oc cp places files directly in coverage_dir, not nested
     mkdir -p "${coverage_dir}"
-    oc cp "${NAMESPACE}/coverage-extractor:${GOCOVERDIR_PATH}/." "${coverage_dir}"
+    echo "Copying coverage data from operator pod..."
+    oc cp "${NAMESPACE}/${pod}:${GOCOVERDIR_PATH}/." "${coverage_dir}" -c manager
 
     echo "Coverage files:"
     ls -la "${coverage_dir}/" 2>/dev/null || true
@@ -137,7 +109,6 @@ collect() {
             curl -sS -o "${codecov_bin}.SHA256SUM"    https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -sS -o "${codecov_bin}.SHA256SUM.sig" https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
 
-            # Verify integrity: import Codecov's PGP key, check signature, then checksum
             if command -v gpg >/dev/null 2>&1 && command -v gpgv >/dev/null 2>&1; then
                 curl -sS https://keybase.io/codecovsecurity/pgp_keys.asc \
                     | gpg --no-default-keyring --keyring trustedkeys.gpg --import 2>/dev/null || true
@@ -157,9 +128,6 @@ collect() {
                 --verbose
             )
 
-            # Pass Prow context so Codecov correctly attributes the upload.
-            # Presubmits: associate with the PR number and PR head SHA.
-            # Postsubmits: associate with the base branch and merge SHA.
             local job_type="${JOB_TYPE:-local}"
             if [[ "${job_type}" == "presubmit" ]]; then
                 echo "Detected presubmit (PR #${PULL_NUMBER:-unknown})"

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -94,9 +94,6 @@ collect() {
     # Clean up any leftover extractor pod from a prior run
     oc delete pod coverage-extractor -n "${NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true
 
-    # Ensure the extractor pod is always cleaned up, even if the script fails
-    trap 'oc delete pod coverage-extractor -n "${NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true' EXIT
-
     echo "Creating extractor pod to access PVC data..."
     oc run coverage-extractor \
         --image="${EXTRACTOR_IMAGE}" \

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -157,7 +157,6 @@ collect() {
                 --file="${coverage_profile}"
                 --flags=e2e
                 --name="E2E Coverage"
-                --token="${CODECOV_TOKEN}"
                 --verbose
             )
 

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -44,12 +44,10 @@ spec:
       storage: 1Gi
 EOF
 
-    echo "Discovering CSV..."
+    echo "Discovering CSV from deployment ownerReference..."
     local csv
-    csv=$(oc get csv -n "${NAMESPACE}" -o name \
-        | grep zero-trust-workload-identity-manager \
-        | head -1 \
-        | sed 's|^clusterserviceversion.operators.coreos.com/||')
+    csv=$(oc get deployment "${DEPLOYMENT}" -n "${NAMESPACE}" \
+        -o jsonpath='{.metadata.ownerReferences[?(@.kind=="ClusterServiceVersion")].name}')
     if [[ -z "${csv}" ]]; then
         echo "Error: no CSV found for zero-trust-workload-identity-manager"
         exit 1

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -134,12 +134,35 @@ collect() {
             local codecov_bin="${artifact_dir}/codecov"
             curl -sS -o "${codecov_bin}" https://uploader.codecov.io/latest/linux/codecov
             chmod +x "${codecov_bin}"
-            "${codecov_bin}" \
-                --file="${coverage_profile}" \
-                --flags=e2e \
-                --name="E2E Coverage" \
-                --token="${CODECOV_TOKEN}" \
-                --verbose || echo "Warning: Codecov upload failed (non-fatal)"
+
+            local -a codecov_args=(
+                --file="${coverage_profile}"
+                --flags=e2e
+                --name="E2E Coverage"
+                --token="${CODECOV_TOKEN}"
+                --verbose
+            )
+
+            # Pass Prow context so Codecov correctly attributes the upload.
+            # Presubmits: associate with the PR number and PR head SHA.
+            # Postsubmits: associate with the base branch and merge SHA.
+            local job_type="${JOB_TYPE:-local}"
+            if [[ "${job_type}" == "presubmit" ]]; then
+                echo "Detected presubmit (PR #${PULL_NUMBER:-unknown})"
+                [[ -n "${PULL_NUMBER:-}" ]]    && codecov_args+=(--pr "${PULL_NUMBER}")
+                [[ -n "${PULL_PULL_SHA:-}" ]]   && codecov_args+=(--sha "${PULL_PULL_SHA}")
+                [[ -n "${PULL_BASE_REF:-}" ]]   && codecov_args+=(--branch "${PULL_BASE_REF}")
+                [[ -n "${REPO_OWNER:-}" && -n "${REPO_NAME:-}" ]] && codecov_args+=(--slug "${REPO_OWNER}/${REPO_NAME}")
+            elif [[ "${job_type}" == "postsubmit" ]]; then
+                echo "Detected postsubmit (branch ${PULL_BASE_REF:-unknown})"
+                [[ -n "${PULL_BASE_SHA:-}" ]]   && codecov_args+=(--sha "${PULL_BASE_SHA}")
+                [[ -n "${PULL_BASE_REF:-}" ]]   && codecov_args+=(--branch "${PULL_BASE_REF}")
+                [[ -n "${REPO_OWNER:-}" && -n "${REPO_NAME:-}" ]] && codecov_args+=(--slug "${REPO_OWNER}/${REPO_NAME}")
+            else
+                echo "Local run -- no Prow context, Codecov will auto-detect from git"
+            fi
+
+            "${codecov_bin}" "${codecov_args[@]}" || echo "Warning: Codecov upload failed (non-fatal)"
             rm -f "${codecov_bin}"
         else
             echo "CODECOV_TOKEN not set -- skipping Codecov upload."

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -93,6 +93,12 @@ collect() {
     oc wait --for=delete pod -l name=zero-trust-workload-identity-manager \
         -n "${NAMESPACE}" --timeout=60s 2>/dev/null || true
 
+    # Clean up any leftover extractor pod from a prior run
+    oc delete pod coverage-extractor -n "${NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true
+
+    # Ensure the extractor pod is always cleaned up, even if the script fails
+    trap 'oc delete pod coverage-extractor -n "${NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true' EXIT
+
     echo "Creating extractor pod to access PVC data..."
     oc run coverage-extractor \
         --image="${EXTRACTOR_IMAGE}" \
@@ -111,9 +117,9 @@ collect() {
     oc wait pod/coverage-extractor --for=condition=Ready \
         -n "${NAMESPACE}" --timeout=120s
 
+    # Use /. suffix so oc cp places files directly in coverage_dir, not nested
     mkdir -p "${coverage_dir}"
-    oc cp "${NAMESPACE}/coverage-extractor:${GOCOVERDIR_PATH}" "${coverage_dir}"
-    oc delete pod coverage-extractor -n "${NAMESPACE}" --wait=false || true
+    oc cp "${NAMESPACE}/coverage-extractor:${GOCOVERDIR_PATH}/." "${coverage_dir}"
 
     echo "Coverage files:"
     ls -la "${coverage_dir}/" 2>/dev/null || true
@@ -132,7 +138,21 @@ collect() {
         if [[ -n "${CODECOV_TOKEN:-}" ]]; then
             echo "Uploading to Codecov..."
             local codecov_bin="${artifact_dir}/codecov"
-            curl -sS -o "${codecov_bin}" https://uploader.codecov.io/latest/linux/codecov
+            curl -sS -o "${codecov_bin}"              https://uploader.codecov.io/latest/linux/codecov
+            curl -sS -o "${codecov_bin}.SHA256SUM"    https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -sS -o "${codecov_bin}.SHA256SUM.sig" https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+
+            # Verify integrity: import Codecov's PGP key, check signature, then checksum
+            if command -v gpg >/dev/null 2>&1 && command -v gpgv >/dev/null 2>&1; then
+                curl -sS https://keybase.io/codecovsecurity/pgp_keys.asc \
+                    | gpg --no-default-keyring --keyring trustedkeys.gpg --import 2>/dev/null || true
+                if gpgv "${codecov_bin}.SHA256SUM.sig" "${codecov_bin}.SHA256SUM" 2>/dev/null; then
+                    echo "PGP signature verified"
+                else
+                    echo "Warning: PGP signature verification failed (continuing with SHA256 check)"
+                fi
+            fi
+            cd "$(dirname "${codecov_bin}")" && sha256sum -c "$(basename "${codecov_bin}").SHA256SUM" && cd - >/dev/null
             chmod +x "${codecov_bin}"
 
             local -a codecov_args=(
@@ -163,7 +183,7 @@ collect() {
             fi
 
             "${codecov_bin}" "${codecov_args[@]}" || echo "Warning: Codecov upload failed (non-fatal)"
-            rm -f "${codecov_bin}"
+            rm -f "${codecov_bin}" "${codecov_bin}.SHA256SUM" "${codecov_bin}.SHA256SUM.sig"
         else
             echo "CODECOV_TOKEN not set -- skipping Codecov upload."
             echo "Coverage profile saved as artifact: ${coverage_profile}"


### PR DESCRIPTION
- Rewrite `Dockerfile.coverage` as self-contained multi-stage build
- Add `hack/e2e-coverage.sh` for CI coverage setup and collection
- Simplify `Makefile` coverage targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage collection infrastructure and tooling to enhance quality assurance processes.

* **Chores**
  * Updated deployment configuration to support coverage instrumentation in test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->