### PR TITLE
SPIRE-344: Add resource conflict detection to prevent overwriting unmanaged resources

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -39,4 +39,5 @@ const (
 	ReasonReady            string = "Ready"
 	ReasonInProgress       string = "Progressing"
 	ReasonOperandsNotReady string = "OperandsNotReady"
+	ReasonResourceConflict string = "ResourceConflict"
 )

--- a/pkg/controller/spiffe-csi-driver/csi_driver.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver.go
@@ -46,6 +46,13 @@ func (r *SpiffeCsiReconciler) reconcileCSIDriver(ctx context.Context, driver *v1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(CSIDriverAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create CSI driver")
 			statusMgr.AddCondition(CSIDriverAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create CSIDriver: %v", err),
@@ -58,14 +65,6 @@ func (r *SpiffeCsiReconciler) reconcileCSIDriver(ctx context.Context, driver *v1
 			"All CSIDriver resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(CSIDriverAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spiffe-csi-driver/csi_driver.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver.go
@@ -60,6 +60,14 @@ func (r *SpiffeCsiReconciler) reconcileCSIDriver(ctx context.Context, driver *v1
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(CSIDriverAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("CSIDriver exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spiffe-csi-driver/csi_driver.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver.go
@@ -46,11 +46,7 @@ func (r *SpiffeCsiReconciler) reconcileCSIDriver(ctx context.Context, driver *v1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(CSIDriverAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, CSIDriverAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create CSI driver")

--- a/pkg/controller/spiffe-csi-driver/csi_driver_test.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver_test.go
@@ -291,7 +291,7 @@ func TestReconcileCSIDriver(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spiffe-csi-driver/csi_driver_test.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver_test.go
@@ -177,7 +177,7 @@ func TestReconcileCSIDriver(t *testing.T) {
 			},
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
 				existingCSI := &storagev1.CSIDriver{
-					ObjectMeta: metav1.ObjectMeta{Name: "csi.spiffe.io", ResourceVersion: "123"},
+					ObjectMeta: metav1.ObjectMeta{Name: "csi.spiffe.io", ResourceVersion: "123", Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if csi, ok := obj.(*storagev1.CSIDriver); ok {
@@ -204,7 +204,7 @@ func TestReconcileCSIDriver(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "csi.spiffe.io",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -233,7 +233,7 @@ func TestReconcileCSIDriver(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "csi.spiffe.io",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spiffe-csi-driver/daemonset.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset.go
@@ -35,6 +35,13 @@ func (r *SpiffeCsiReconciler) reconcileDaemonSet(ctx context.Context, driver *v1
 	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: spiffeCsiDaemonset.Name, Namespace: spiffeCsiDaemonset.Namespace}, &existingSpiffeCsiDaemonSet)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spiffeCsiDaemonset); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(spiffeCsiDaemonset.GetNamespace(), spiffeCsiDaemonset.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "Failed to create SpiffeCsiDaemon set")
 			statusMgr.AddCondition(DaemonSetAvailable, "SpiffeCSIDaemonSetCreationFailed",
 				err.Error(),
@@ -43,12 +50,6 @@ func (r *SpiffeCsiReconciler) reconcileDaemonSet(ctx context.Context, driver *v1
 		}
 		r.log.Info("Created spiffe csi DaemonSet")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSpiffeCsiDaemonSet); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
-		}
 		if !needsUpdate(existingSpiffeCsiDaemonSet, *spiffeCsiDaemonset) {
 			statusMgr.CheckDaemonSetHealth(ctx, spiffeCsiDaemonset.Name, spiffeCsiDaemonset.Namespace, DaemonSetAvailable)
 			return nil

--- a/pkg/controller/spiffe-csi-driver/daemonset.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset.go
@@ -35,11 +35,7 @@ func (r *SpiffeCsiReconciler) reconcileDaemonSet(ctx context.Context, driver *v1
 	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: spiffeCsiDaemonset.Name, Namespace: spiffeCsiDaemonset.Namespace}, &existingSpiffeCsiDaemonSet)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spiffeCsiDaemonset); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(spiffeCsiDaemonset.GetNamespace(), spiffeCsiDaemonset.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, spiffeCsiDaemonset, r.log, statusMgr, DaemonSetAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "Failed to create SpiffeCsiDaemon set")

--- a/pkg/controller/spiffe-csi-driver/daemonset.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset.go
@@ -42,7 +42,17 @@ func (r *SpiffeCsiReconciler) reconcileDaemonSet(ctx context.Context, driver *v1
 			return fmt.Errorf("failed to create DaemonSet: %w", err)
 		}
 		r.log.Info("Created spiffe csi DaemonSet")
-	} else if err == nil && needsUpdate(existingSpiffeCsiDaemonSet, *spiffeCsiDaemonset) {
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSpiffeCsiDaemonSet); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
+		}
+		if !needsUpdate(existingSpiffeCsiDaemonSet, *spiffeCsiDaemonset) {
+			statusMgr.CheckDaemonSetHealth(ctx, spiffeCsiDaemonset.Name, spiffeCsiDaemonset.Namespace, DaemonSetAvailable)
+			return nil
+		}
 		if createOnlyMode {
 			r.log.Info("Skipping DaemonSet update due to create-only mode")
 		} else {
@@ -56,7 +66,7 @@ func (r *SpiffeCsiReconciler) reconcileDaemonSet(ctx context.Context, driver *v1
 			}
 			r.log.Info("Updated spiffe csi DaemonSet")
 		}
-	} else if err != nil {
+	} else {
 		r.log.Error(err, "Failed to get SpiffeCsiDaemon set")
 		statusMgr.AddCondition(DaemonSetAvailable, "SpiffeCSIDaemonSetGetFailed",
 			err.Error(),

--- a/pkg/controller/spiffe-csi-driver/daemonset_test.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset_test.go
@@ -615,7 +615,7 @@ func TestReconcileDaemonSet(t *testing.T) {
 						Name:            "spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fakeClient.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spiffe-csi-driver/scc.go
+++ b/pkg/controller/spiffe-csi-driver/scc.go
@@ -88,11 +88,7 @@ func (r *SpiffeCsiReconciler) reconcileSCC(ctx context.Context, driver *v1alpha1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, SecurityContextConstraintsAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "Failed to create SpiffeCsiSCC")

--- a/pkg/controller/spiffe-csi-driver/scc.go
+++ b/pkg/controller/spiffe-csi-driver/scc.go
@@ -88,6 +88,13 @@ func (r *SpiffeCsiReconciler) reconcileSCC(ctx context.Context, driver *v1alpha1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "Failed to create SpiffeCsiSCC")
 			statusMgr.AddCondition(SecurityContextConstraintsAvailable, "SpiffeCSISCCCreationFailed",
 				err.Error(),
@@ -100,14 +107,6 @@ func (r *SpiffeCsiReconciler) reconcileSCC(ctx context.Context, driver *v1alpha1
 			"SpiffeCSISCC resource created",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Preserve fields set by OpenShift from existing resource BEFORE comparison

--- a/pkg/controller/spiffe-csi-driver/scc.go
+++ b/pkg/controller/spiffe-csi-driver/scc.go
@@ -102,6 +102,14 @@ func (r *SpiffeCsiReconciler) reconcileSCC(ctx context.Context, driver *v1alpha1
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Preserve fields set by OpenShift from existing resource BEFORE comparison
 	desired.ResourceVersion = existing.ResourceVersion
 	desired.Priority = existing.Priority

--- a/pkg/controller/spiffe-csi-driver/scc_test.go
+++ b/pkg/controller/spiffe-csi-driver/scc_test.go
@@ -601,7 +601,7 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-spiffe-csi-driver",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -629,7 +629,7 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-spiffe-csi-driver",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spiffe-csi-driver/scc_test.go
+++ b/pkg/controller/spiffe-csi-driver/scc_test.go
@@ -686,7 +686,7 @@ func TestReconcileSCC(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spiffe-csi-driver/service_account.go
+++ b/pkg/controller/spiffe-csi-driver/service_account.go
@@ -46,11 +46,7 @@ func (r *SpiffeCsiReconciler) reconcileServiceAccount(ctx context.Context, drive
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAccountAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service account")

--- a/pkg/controller/spiffe-csi-driver/service_account.go
+++ b/pkg/controller/spiffe-csi-driver/service_account.go
@@ -46,6 +46,13 @@ func (r *SpiffeCsiReconciler) reconcileServiceAccount(ctx context.Context, drive
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service account")
 			statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ServiceAccount: %v", err),
@@ -58,14 +65,6 @@ func (r *SpiffeCsiReconciler) reconcileServiceAccount(ctx context.Context, drive
 			"All ServiceAccount resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spiffe-csi-driver/service_account.go
+++ b/pkg/controller/spiffe-csi-driver/service_account.go
@@ -60,6 +60,14 @@ func (r *SpiffeCsiReconciler) reconcileServiceAccount(ctx context.Context, drive
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spiffe-csi-driver/service_account_test.go
+++ b/pkg/controller/spiffe-csi-driver/service_account_test.go
@@ -245,7 +245,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spiffe-csi-driver/service_account_test.go
+++ b/pkg/controller/spiffe-csi-driver/service_account_test.go
@@ -118,6 +118,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -145,7 +146,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -174,7 +175,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -187,6 +188,28 @@ func TestReconcileServiceAccount(t *testing.T) {
 			},
 			expectError:  true,
 			expectUpdate: true,
+		},
+		{
+			name: "resource conflict - existing resource not managed by operator",
+			driver: &v1alpha1.SpiffeCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingSA := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-spiffe-csi-driver",
+						Namespace:       utils.GetOperatorNamespace(),
+						ResourceVersion: "123",
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if sa, ok := obj.(*corev1.ServiceAccount); ok {
+						*sa = *existingSA
+					}
+					return nil
+				}
+			},
+			expectError: true,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spiffe-csi-driver/service_account_test.go
+++ b/pkg/controller/spiffe-csi-driver/service_account_test.go
@@ -190,26 +190,17 @@ func TestReconcileServiceAccount(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name: "resource conflict - existing resource not managed by operator",
+			name: "resource conflict - create returns AlreadyExists",
 			driver: &v1alpha1.SpiffeCSIDriver{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
 			},
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
-				existingSA := &corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "spire-spiffe-csi-driver",
-						Namespace:       utils.GetOperatorNamespace(),
-						ResourceVersion: "123",
-					},
-				}
-				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					if sa, ok := obj.(*corev1.ServiceAccount); ok {
-						*sa = *existingSA
-					}
-					return nil
-				}
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spire-spiffe-csi-driver"))
+				fc.CreateReturns(kerrors.NewAlreadyExists(schema.GroupResource{Resource: "serviceaccounts"}, "spire-spiffe-csi-driver"))
 			},
-			expectError: true,
+			expectError:  true,
+			expectCreate: true,
+			expectUpdate: false,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-agent/configmap.go
+++ b/pkg/controller/spire-agent/configmap.go
@@ -49,22 +49,30 @@ func (r *SpireAgentReconciler) reconcileConfigMap(ctx context.Context, agent *v1
 			return "", fmt.Errorf("failed to create ConfigMap: %w", err)
 		}
 		r.log.Info("Created spire agent ConfigMap")
-	} else if err == nil && (existingSpireAgentCM.Data["agent.conf"] != spireAgentConfigMap.Data["agent.conf"] ||
-		!equality.Semantic.DeepEqual(existingSpireAgentCM.Labels, spireAgentConfigMap.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping ConfigMap update due to create-only mode")
-		} else {
-			spireAgentConfigMap.ResourceVersion = existingSpireAgentCM.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireAgentConfigMap); err != nil {
-				r.log.Error(err, "failed to update spire-agent config map")
-				statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", fmt.Errorf("failed to update ConfigMap: %w", err)
-			}
-			r.log.Info("Updated ConfigMap with new config")
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSpireAgentCM); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return "", conflictErr
 		}
-	} else if err != nil {
+		if existingSpireAgentCM.Data["agent.conf"] != spireAgentConfigMap.Data["agent.conf"] ||
+			!equality.Semantic.DeepEqual(existingSpireAgentCM.Labels, spireAgentConfigMap.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping ConfigMap update due to create-only mode")
+			} else {
+				spireAgentConfigMap.ResourceVersion = existingSpireAgentCM.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireAgentConfigMap); err != nil {
+					r.log.Error(err, "failed to update spire-agent config map")
+					statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+				}
+				r.log.Info("Updated ConfigMap with new config")
+			}
+		}
+	} else {
 		statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",
 			err.Error(),
 			metav1.ConditionFalse)

--- a/pkg/controller/spire-agent/configmap.go
+++ b/pkg/controller/spire-agent/configmap.go
@@ -42,11 +42,7 @@ func (r *SpireAgentReconciler) reconcileConfigMap(ctx context.Context, agent *v1
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireAgentConfigMap.Name, Namespace: spireAgentConfigMap.Namespace}, &existingSpireAgentCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireAgentConfigMap); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(spireAgentConfigMap.GetNamespace(), spireAgentConfigMap.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, spireAgentConfigMap, r.log, statusMgr, ConfigMapAvailable); conflictErr != nil {
 				return "", conflictErr
 			}
 			r.log.Error(err, "failed to create spire-agent config map")

--- a/pkg/controller/spire-agent/configmap.go
+++ b/pkg/controller/spire-agent/configmap.go
@@ -42,6 +42,13 @@ func (r *SpireAgentReconciler) reconcileConfigMap(ctx context.Context, agent *v1
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireAgentConfigMap.Name, Namespace: spireAgentConfigMap.Namespace}, &existingSpireAgentCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireAgentConfigMap); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(spireAgentConfigMap.GetNamespace(), spireAgentConfigMap.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return "", conflictErr
+			}
 			r.log.Error(err, "failed to create spire-agent config map")
 			statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",
 				err.Error(),
@@ -50,13 +57,7 @@ func (r *SpireAgentReconciler) reconcileConfigMap(ctx context.Context, agent *v1
 		}
 		r.log.Info("Created spire agent ConfigMap")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSpireAgentCM); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return "", conflictErr
-		}
-		if existingSpireAgentCM.Data["agent.conf"] != spireAgentConfigMap.Data["agent.conf"] ||
+		if existingSpireAgentCM.Data[utils.SpireAgentConfigKey] != spireAgentConfigMap.Data[utils.SpireAgentConfigKey] ||
 			!equality.Semantic.DeepEqual(existingSpireAgentCM.Labels, spireAgentConfigMap.Labels) {
 			if createOnlyMode {
 				r.log.Info("Skipping ConfigMap update due to create-only mode")
@@ -216,7 +217,7 @@ func generateSpireAgentConfigMap(spireAgentConfig *v1alpha1.SpireAgent, ztwim *v
 			},
 		},
 		Data: map[string]string{
-			"agent.conf": string(agentConfigJSON),
+			utils.SpireAgentConfigKey: string(agentConfigJSON),
 		},
 	}
 

--- a/pkg/controller/spire-agent/configmap_test.go
+++ b/pkg/controller/spire-agent/configmap_test.go
@@ -461,13 +461,13 @@ func TestGenerateSpireAgentConfigMap(t *testing.T) {
 			assert.Equal(t, expectedAnnotations, cm.Annotations)
 
 			// Validate ConfigMap data
-			assert.Contains(t, cm.Data, "agent.conf")
-			assert.NotEmpty(t, cm.Data["agent.conf"])
+			assert.Contains(t, cm.Data, utils.SpireAgentConfigKey)
+			assert.NotEmpty(t, cm.Data[utils.SpireAgentConfigKey])
 
 			if tt.validateConfigData {
 				// Validate that the config data is valid JSON
 				var configData map[string]interface{}
-				err := json.Unmarshal([]byte(cm.Data["agent.conf"]), &configData)
+				err := json.Unmarshal([]byte(cm.Data[utils.SpireAgentConfigKey]), &configData)
 				require.NoError(t, err)
 
 				// Validate basic structure
@@ -496,7 +496,7 @@ func TestGenerateSpireAgentConfigMap(t *testing.T) {
 				cm2, hash2, err2 := generateSpireAgentConfigMap(tt.spireAgentConfig, tt.ztwim)
 				require.NoError(t, err2)
 				assert.Equal(t, hash, hash2)
-				assert.Equal(t, cm.Data["agent.conf"], cm2.Data["agent.conf"])
+				assert.Equal(t, cm.Data[utils.SpireAgentConfigKey], cm2.Data[utils.SpireAgentConfigKey])
 			}
 		})
 	}
@@ -541,8 +541,8 @@ func TestGenerateSpireAgentConfigMapConsistency(t *testing.T) {
 	// All results should be identical
 	assert.Equal(t, hash1, hash2)
 	assert.Equal(t, hash2, hash3)
-	assert.Equal(t, cm1.Data["agent.conf"], cm2.Data["agent.conf"])
-	assert.Equal(t, cm2.Data["agent.conf"], cm3.Data["agent.conf"])
+	assert.Equal(t, cm1.Data[utils.SpireAgentConfigKey], cm2.Data[utils.SpireAgentConfigKey])
+	assert.Equal(t, cm2.Data[utils.SpireAgentConfigKey], cm3.Data[utils.SpireAgentConfigKey])
 }
 
 func TestGenerateAgentConfigNilChecks(t *testing.T) {

--- a/pkg/controller/spire-agent/controller_test.go
+++ b/pkg/controller/spire-agent/controller_test.go
@@ -1257,7 +1257,7 @@ func TestReconcile_FullFlow_AllScenarios(t *testing.T) {
 						v.Namespace = key.Namespace
 						v.Labels = map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}
 						if tt.configMapDiff {
-							v.Data = map[string]string{"agent.conf": "old-config"}
+							v.Data = map[string]string{utils.SpireAgentConfigKey: "old-config"}
 						}
 						return nil
 					}
@@ -1383,7 +1383,7 @@ func TestReconcileConfigMap_AllScenarios(t *testing.T) {
 						v.Namespace = key.Namespace
 						v.Labels = map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}
 						if tt.cmDiff {
-							v.Data = map[string]string{"agent.conf": "old-config"}
+							v.Data = map[string]string{utils.SpireAgentConfigKey: "old-config"}
 						}
 						return nil
 					}

--- a/pkg/controller/spire-agent/controller_test.go
+++ b/pkg/controller/spire-agent/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/client/fakes"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/status"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1254,6 +1255,7 @@ func TestReconcile_FullFlow_AllScenarios(t *testing.T) {
 					if tt.configMapExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}
 						if tt.configMapDiff {
 							v.Data = map[string]string{"agent.conf": "old-config"}
 						}
@@ -1264,6 +1266,7 @@ func TestReconcile_FullFlow_AllScenarios(t *testing.T) {
 					if tt.daemonSetExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}
 						return nil
 					}
 					return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
@@ -1378,6 +1381,7 @@ func TestReconcileConfigMap_AllScenarios(t *testing.T) {
 					if tt.cmExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}
 						if tt.cmDiff {
 							v.Data = map[string]string{"agent.conf": "old-config"}
 						}
@@ -1494,8 +1498,8 @@ func TestReconcileDaemonSet_AllScenarios(t *testing.T) {
 					if tt.dsExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}
 						if !tt.dsDiff {
-							// Set same hash to simulate no change needed
 							v.Spec.Template.Annotations = map[string]string{
 								spireAgentDaemonSetSpireAgentConfigHashAnnotationKey: "test-hash",
 							}

--- a/pkg/controller/spire-agent/daemonset.go
+++ b/pkg/controller/spire-agent/daemonset.go
@@ -34,11 +34,7 @@ func (r *SpireAgentReconciler) reconcileDaemonSet(ctx context.Context, agent *v1
 	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireAgentDaemonset.Name, Namespace: spireAgentDaemonset.Namespace}, &existingSpireAgentDaemonSet)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireAgentDaemonset); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(spireAgentDaemonset.GetNamespace(), spireAgentDaemonset.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, spireAgentDaemonset, r.log, statusMgr, DaemonSetAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create spire-agent daemonset")

--- a/pkg/controller/spire-agent/daemonset.go
+++ b/pkg/controller/spire-agent/daemonset.go
@@ -41,7 +41,17 @@ func (r *SpireAgentReconciler) reconcileDaemonSet(ctx context.Context, agent *v1
 			return fmt.Errorf("failed to create DaemonSet: %w", err)
 		}
 		r.log.Info("Created spire agent DaemonSet")
-	} else if err == nil && needsUpdate(existingSpireAgentDaemonSet, *spireAgentDaemonset) {
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSpireAgentDaemonSet); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
+		}
+		if !needsUpdate(existingSpireAgentDaemonSet, *spireAgentDaemonset) {
+			statusMgr.CheckDaemonSetHealth(ctx, spireAgentDaemonset.Name, spireAgentDaemonset.Namespace, DaemonSetAvailable)
+			return nil
+		}
 		if createOnlyMode {
 			r.log.Info("Skipping DaemonSet update due to create-only mode")
 		} else {
@@ -55,7 +65,7 @@ func (r *SpireAgentReconciler) reconcileDaemonSet(ctx context.Context, agent *v1
 			}
 			r.log.Info("Updated spire agent DaemonSet")
 		}
-	} else if err != nil {
+	} else {
 		r.log.Error(err, "failed to get spire-agent daemonset")
 		statusMgr.AddCondition(DaemonSetAvailable, "SpireAgentDaemonSetGetFailed",
 			err.Error(),

--- a/pkg/controller/spire-agent/daemonset.go
+++ b/pkg/controller/spire-agent/daemonset.go
@@ -34,6 +34,13 @@ func (r *SpireAgentReconciler) reconcileDaemonSet(ctx context.Context, agent *v1
 	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireAgentDaemonset.Name, Namespace: spireAgentDaemonset.Namespace}, &existingSpireAgentDaemonSet)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireAgentDaemonset); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(spireAgentDaemonset.GetNamespace(), spireAgentDaemonset.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create spire-agent daemonset")
 			statusMgr.AddCondition(DaemonSetAvailable, "SpireAgentDaemonSetCreationFailed",
 				err.Error(),
@@ -42,12 +49,6 @@ func (r *SpireAgentReconciler) reconcileDaemonSet(ctx context.Context, agent *v1
 		}
 		r.log.Info("Created spire agent DaemonSet")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSpireAgentDaemonSet); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
-		}
 		if !needsUpdate(existingSpireAgentDaemonSet, *spireAgentDaemonset) {
 			statusMgr.CheckDaemonSetHealth(ctx, spireAgentDaemonset.Name, spireAgentDaemonset.Namespace, DaemonSetAvailable)
 			return nil

--- a/pkg/controller/spire-agent/rbac.go
+++ b/pkg/controller/spire-agent/rbac.go
@@ -77,7 +77,14 @@ func (r *SpireAgentReconciler) reconcileClusterRole(ctx context.Context, agent *
 		return nil
 	}
 
-	// Resource exists, check if we need to update
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRole exists, skipping update due to create-only mode", "name", desired.Name)
 		return nil
@@ -142,7 +149,14 @@ func (r *SpireAgentReconciler) reconcileClusterRoleBinding(ctx context.Context, 
 		return nil
 	}
 
-	// Resource exists, check if we need to update
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRoleBinding exists, skipping update due to create-only mode", "name", desired.Name)
 		return nil

--- a/pkg/controller/spire-agent/rbac.go
+++ b/pkg/controller/spire-agent/rbac.go
@@ -66,6 +66,13 @@ func (r *SpireAgentReconciler) reconcileClusterRole(ctx context.Context, agent *
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create cluster role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ClusterRole: %v", err),
@@ -75,14 +82,6 @@ func (r *SpireAgentReconciler) reconcileClusterRole(ctx context.Context, agent *
 
 		r.log.Info("Created ClusterRole", "name", desired.Name)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	if createOnlyMode {
@@ -138,6 +137,13 @@ func (r *SpireAgentReconciler) reconcileClusterRoleBinding(ctx context.Context, 
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create cluster role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ClusterRoleBinding: %v", err),
@@ -147,14 +153,6 @@ func (r *SpireAgentReconciler) reconcileClusterRoleBinding(ctx context.Context, 
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	if createOnlyMode {

--- a/pkg/controller/spire-agent/rbac.go
+++ b/pkg/controller/spire-agent/rbac.go
@@ -66,11 +66,7 @@ func (r *SpireAgentReconciler) reconcileClusterRole(ctx context.Context, agent *
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create cluster role")
@@ -137,11 +133,7 @@ func (r *SpireAgentReconciler) reconcileClusterRoleBinding(ctx context.Context, 
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create cluster role binding")

--- a/pkg/controller/spire-agent/rbac_test.go
+++ b/pkg/controller/spire-agent/rbac_test.go
@@ -275,6 +275,7 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -303,7 +304,7 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -332,7 +333,7 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -450,6 +451,7 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -478,7 +480,7 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -507,7 +509,7 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-agent/scc.go
+++ b/pkg/controller/spire-agent/scc.go
@@ -90,6 +90,13 @@ func (r *SpireAgentReconciler) reconcileSCC(ctx context.Context, agent *v1alpha1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "Failed to create SpireAgentSCC")
 			statusMgr.AddCondition(SecurityContextConstraintsAvailable, "SpireAgentSCCCreationFailed",
 				err.Error(),
@@ -102,14 +109,6 @@ func (r *SpireAgentReconciler) reconcileSCC(ctx context.Context, agent *v1alpha1
 			"Spire Agent SCC resources applied",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Preserve fields set by OpenShift from existing resource BEFORE comparison

--- a/pkg/controller/spire-agent/scc.go
+++ b/pkg/controller/spire-agent/scc.go
@@ -90,11 +90,7 @@ func (r *SpireAgentReconciler) reconcileSCC(ctx context.Context, agent *v1alpha1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, SecurityContextConstraintsAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "Failed to create SpireAgentSCC")

--- a/pkg/controller/spire-agent/scc.go
+++ b/pkg/controller/spire-agent/scc.go
@@ -104,6 +104,14 @@ func (r *SpireAgentReconciler) reconcileSCC(ctx context.Context, agent *v1alpha1
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Preserve fields set by OpenShift from existing resource BEFORE comparison
 	desired.ResourceVersion = existing.ResourceVersion
 	desired.Priority = existing.Priority

--- a/pkg/controller/spire-agent/scc_test.go
+++ b/pkg/controller/spire-agent/scc_test.go
@@ -289,7 +289,7 @@ func TestReconcileSCC(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spire-agent/scc_test.go
+++ b/pkg/controller/spire-agent/scc_test.go
@@ -204,7 +204,7 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -232,7 +232,7 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -317,7 +317,7 @@ func TestReconcileSCC_PreservesExistingFields(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "spire-agent",
 			ResourceVersion: "123",
-			Labels:          map[string]string{"old-label": "old-value"},
+			Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 		},
 		Priority:           func() *int32 { p := int32(10); return &p }(),
 		UserNamespaceLevel: "pod",

--- a/pkg/controller/spire-agent/service.go
+++ b/pkg/controller/spire-agent/service.go
@@ -69,7 +69,14 @@ func (r *SpireAgentReconciler) reconcileAgentService(ctx context.Context, agent 
 		return nil
 	}
 
-	// Resource exists, check if we need to update
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	if createOnlyMode {
 		r.log.V(1).Info("Service exists, skipping update due to create-only mode", "name", desired.Name)
 		return nil

--- a/pkg/controller/spire-agent/service.go
+++ b/pkg/controller/spire-agent/service.go
@@ -58,6 +58,13 @@ func (r *SpireAgentReconciler) reconcileAgentService(ctx context.Context, agent 
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service")
 			statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Service: %v", err),
@@ -67,14 +74,6 @@ func (r *SpireAgentReconciler) reconcileAgentService(ctx context.Context, agent 
 
 		r.log.Info("Created Service", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	if createOnlyMode {

--- a/pkg/controller/spire-agent/service.go
+++ b/pkg/controller/spire-agent/service.go
@@ -58,11 +58,7 @@ func (r *SpireAgentReconciler) reconcileAgentService(ctx context.Context, agent 
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service")

--- a/pkg/controller/spire-agent/service_account.go
+++ b/pkg/controller/spire-agent/service_account.go
@@ -60,7 +60,14 @@ func (r *SpireAgentReconciler) reconcileServiceAccount(ctx context.Context, agen
 		return nil
 	}
 
-	// Resource exists, check if we need to update
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)
 		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonReady,

--- a/pkg/controller/spire-agent/service_account.go
+++ b/pkg/controller/spire-agent/service_account.go
@@ -46,6 +46,13 @@ func (r *SpireAgentReconciler) reconcileServiceAccount(ctx context.Context, agen
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service account")
 			statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ServiceAccount: %v", err),
@@ -58,14 +65,6 @@ func (r *SpireAgentReconciler) reconcileServiceAccount(ctx context.Context, agen
 			"All ServiceAccount resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	if createOnlyMode {

--- a/pkg/controller/spire-agent/service_account.go
+++ b/pkg/controller/spire-agent/service_account.go
@@ -46,11 +46,7 @@ func (r *SpireAgentReconciler) reconcileServiceAccount(ctx context.Context, agen
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAccountAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service account")

--- a/pkg/controller/spire-agent/service_account_test.go
+++ b/pkg/controller/spire-agent/service_account_test.go
@@ -164,6 +164,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -207,7 +208,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -236,7 +237,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -249,6 +250,28 @@ func TestReconcileServiceAccount(t *testing.T) {
 			},
 			expectError:  true,
 			expectUpdate: true,
+		},
+		{
+			name: "resource conflict - existing resource not managed by operator",
+			agent: &v1alpha1.SpireAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingSA := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-agent",
+						Namespace:       utils.GetOperatorNamespace(),
+						ResourceVersion: "123",
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if sa, ok := obj.(*corev1.ServiceAccount); ok {
+						*sa = *existingSA
+					}
+					return nil
+				}
+			},
+			expectError: true,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-agent/service_account_test.go
+++ b/pkg/controller/spire-agent/service_account_test.go
@@ -307,7 +307,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spire-agent/service_account_test.go
+++ b/pkg/controller/spire-agent/service_account_test.go
@@ -252,26 +252,17 @@ func TestReconcileServiceAccount(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name: "resource conflict - existing resource not managed by operator",
+			name: "resource conflict - create returns AlreadyExists",
 			agent: &v1alpha1.SpireAgent{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
 			},
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
-				existingSA := &corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "spire-agent",
-						Namespace:       utils.GetOperatorNamespace(),
-						ResourceVersion: "123",
-					},
-				}
-				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					if sa, ok := obj.(*corev1.ServiceAccount); ok {
-						*sa = *existingSA
-					}
-					return nil
-				}
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spire-agent"))
+				fc.CreateReturns(kerrors.NewAlreadyExists(schema.GroupResource{Resource: "serviceaccounts"}, "spire-agent"))
 			},
-			expectError: true,
+			expectError:  true,
+			expectCreate: true,
+			expectUpdate: false,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-agent/service_test.go
+++ b/pkg/controller/spire-agent/service_test.go
@@ -288,7 +288,7 @@ func TestReconcileAgentService(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spire-agent/service_test.go
+++ b/pkg/controller/spire-agent/service_test.go
@@ -172,6 +172,7 @@ func TestReconcileAgentService(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -199,7 +200,7 @@ func TestReconcileAgentService(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -229,7 +230,7 @@ func TestReconcileAgentService(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}

--- a/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
+++ b/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
@@ -51,6 +51,12 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 		}
 		r.log.Info("Created OIDC ClusterSPIFFEID", "name", desiredOIDC.Name)
 	} else {
+		if conflictErr := utils.CheckResourceConflict(existingOIDC); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
+		}
 		// Resource exists, check if we need to update
 		if utils.ResourceNeedsUpdate(existingOIDC, desiredOIDC) {
 			if createOnlyMode {
@@ -107,6 +113,12 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 		}
 		r.log.Info("Created Default ClusterSPIFFEID", "name", desiredDefault.Name)
 	} else {
+		if conflictErr := utils.CheckResourceConflict(existingDefault); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
+		}
 		// Resource exists, check if we need to update
 		if utils.ResourceNeedsUpdate(existingDefault, desiredDefault) {
 			if createOnlyMode {

--- a/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
+++ b/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
@@ -43,11 +43,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desiredOIDC); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desiredOIDC.GetNamespace(), desiredOIDC.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desiredOIDC, r.log, statusMgr, ClusterSPIFFEIDAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "Failed to create oidc cluster spiffe id")
@@ -106,11 +102,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desiredDefault); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desiredDefault.GetNamespace(), desiredDefault.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desiredDefault, r.log, statusMgr, ClusterSPIFFEIDAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "Failed to create DefaultFallbackClusterSPIFFEID")

--- a/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
+++ b/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
@@ -43,6 +43,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desiredOIDC); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desiredOIDC.GetNamespace(), desiredOIDC.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "Failed to create oidc cluster spiffe id")
 			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, "SpireClusterSpiffeIDCreationFailed",
 				err.Error(),
@@ -51,12 +58,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 		}
 		r.log.Info("Created OIDC ClusterSPIFFEID", "name", desiredOIDC.Name)
 	} else {
-		if conflictErr := utils.CheckResourceConflict(existingOIDC); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
-		}
 		// Resource exists, check if we need to update
 		if utils.ResourceNeedsUpdate(existingOIDC, desiredOIDC) {
 			if createOnlyMode {
@@ -105,6 +106,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desiredDefault); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desiredDefault.GetNamespace(), desiredDefault.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "Failed to create DefaultFallbackClusterSPIFFEID")
 			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, "SpireClusterSpiffeIDCreationFailed",
 				err.Error(),
@@ -113,12 +121,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 		}
 		r.log.Info("Created Default ClusterSPIFFEID", "name", desiredDefault.Name)
 	} else {
-		if conflictErr := utils.CheckResourceConflict(existingDefault); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
-		}
 		// Resource exists, check if we need to update
 		if utils.ResourceNeedsUpdate(existingDefault, desiredDefault) {
 			if createOnlyMode {

--- a/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/client/fakes"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/status"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
 	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +98,7 @@ func TestReconcileClusterSpiffeIDs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-oidc-discovery-provider",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fakeClient.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps.go
@@ -49,22 +49,30 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileConfigMap(ctx context.Co
 			return "", err
 		}
 		r.log.Info("Created ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
-	} else if err == nil && (utils.GenerateMapHash(existingOidcCm.Data) != utils.GenerateMapHash(cm.Data) ||
-		!equality.Semantic.DeepEqual(existingOidcCm.Labels, cm.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping ConfigMap update due to create-only mode", "Namespace", cm.Namespace, "Name", cm.Name)
-		} else {
-			cm.ResourceVersion = existingOidcCm.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, cm); err != nil {
-				r.log.Error(err, "Failed to update ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
-				statusMgr.AddCondition(ConfigMapAvailable, "SpireOIDCConfigMapCreationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", err
-			}
-			r.log.Info("Updated ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingOidcCm); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return "", conflictErr
 		}
-	} else if err != nil {
+		if utils.GenerateMapHash(existingOidcCm.Data) != utils.GenerateMapHash(cm.Data) ||
+			!equality.Semantic.DeepEqual(existingOidcCm.Labels, cm.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping ConfigMap update due to create-only mode", "Namespace", cm.Namespace, "Name", cm.Name)
+			} else {
+				cm.ResourceVersion = existingOidcCm.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, cm); err != nil {
+					r.log.Error(err, "Failed to update ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
+					statusMgr.AddCondition(ConfigMapAvailable, "SpireOIDCConfigMapCreationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", err
+				}
+				r.log.Info("Updated ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
+			}
+		}
+	} else {
 		r.log.Error(err, "Failed to get ConfigMap")
 		statusMgr.AddCondition(ConfigMapAvailable, "SpireOIDCConfigMapCreationFailed",
 			err.Error(),

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps.go
@@ -42,11 +42,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileConfigMap(ctx context.Co
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, &existingOidcCm)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, cm); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(cm.GetNamespace(), cm.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, cm, r.log, statusMgr, ConfigMapAvailable); conflictErr != nil {
 				return "", conflictErr
 			}
 			r.log.Error(err, "Failed to create ConfigMap")

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps.go
@@ -42,6 +42,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileConfigMap(ctx context.Co
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, &existingOidcCm)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, cm); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(cm.GetNamespace(), cm.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return "", conflictErr
+			}
 			r.log.Error(err, "Failed to create ConfigMap")
 			statusMgr.AddCondition(ConfigMapAvailable, "SpireOIDCConfigMapCreationFailed",
 				err.Error(),
@@ -50,12 +57,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileConfigMap(ctx context.Co
 		}
 		r.log.Info("Created ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingOidcCm); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return "", conflictErr
-		}
 		if utils.GenerateMapHash(existingOidcCm.Data) != utils.GenerateMapHash(cm.Data) ||
 			!equality.Semantic.DeepEqual(existingOidcCm.Labels, cm.Labels) {
 			if createOnlyMode {

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps_test.go
@@ -98,6 +98,7 @@ func TestReconcileConfigMap(t *testing.T) {
 				Name:            "spire-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 			},
 			Data: map[string]string{
 				"oidc-discovery-provider.conf": "old-config",
@@ -138,6 +139,7 @@ func TestReconcileConfigMap(t *testing.T) {
 				Name:            "spire-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 			},
 			Data: map[string]string{
 				"oidc-discovery-provider.conf": "old-config",
@@ -172,6 +174,7 @@ func TestReconcileConfigMap(t *testing.T) {
 				Name:            "spire-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 			},
 			Data: map[string]string{
 				"oidc-discovery-provider.conf": "old-config",

--- a/pkg/controller/spire-oidc-discovery-provider/deployments.go
+++ b/pkg/controller/spire-oidc-discovery-provider/deployments.go
@@ -34,11 +34,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileDeployment(ctx context.C
 	}, &existingSpireOidcDeployment)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, deployment); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(deployment.GetNamespace(), deployment.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(DeploymentAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, deployment, r.log, statusMgr, DeploymentAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "Failed to create spire oidc discovery provider deployment")

--- a/pkg/controller/spire-oidc-discovery-provider/deployments.go
+++ b/pkg/controller/spire-oidc-discovery-provider/deployments.go
@@ -34,6 +34,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileDeployment(ctx context.C
 	}, &existingSpireOidcDeployment)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, deployment); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(deployment.GetNamespace(), deployment.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(DeploymentAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "Failed to create spire oidc discovery provider deployment")
 			statusMgr.AddCondition(DeploymentAvailable, "SpireOIDCDeploymentCreationFailed",
 				err.Error(),
@@ -42,12 +49,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileDeployment(ctx context.C
 		}
 		r.log.Info("Created spire oidc discovery provider deployment")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSpireOidcDeployment); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(DeploymentAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
-		}
 		if needsUpdate(existingSpireOidcDeployment, *deployment) {
 			if createOnlyMode {
 				r.log.Info("Skipping Deployment update due to create-only mode")

--- a/pkg/controller/spire-oidc-discovery-provider/deployments.go
+++ b/pkg/controller/spire-oidc-discovery-provider/deployments.go
@@ -41,21 +41,29 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileDeployment(ctx context.C
 			return err
 		}
 		r.log.Info("Created spire oidc discovery provider deployment")
-	} else if err == nil && needsUpdate(existingSpireOidcDeployment, *deployment) {
-		if createOnlyMode {
-			r.log.Info("Skipping Deployment update due to create-only mode")
-		} else {
-			deployment.ResourceVersion = existingSpireOidcDeployment.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, deployment); err != nil {
-				r.log.Error(err, "Failed to update spire oidc discovery provider deployment")
-				statusMgr.AddCondition(DeploymentAvailable, "SpireOIDCDeploymentUpdateFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return err
-			}
-			r.log.Info("Updated spire oidc discovery provider deployment")
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSpireOidcDeployment); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(DeploymentAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
 		}
-	} else if err != nil {
+		if needsUpdate(existingSpireOidcDeployment, *deployment) {
+			if createOnlyMode {
+				r.log.Info("Skipping Deployment update due to create-only mode")
+			} else {
+				deployment.ResourceVersion = existingSpireOidcDeployment.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, deployment); err != nil {
+					r.log.Error(err, "Failed to update spire oidc discovery provider deployment")
+					statusMgr.AddCondition(DeploymentAvailable, "SpireOIDCDeploymentUpdateFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return err
+				}
+				r.log.Info("Updated spire oidc discovery provider deployment")
+			}
+		}
+	} else {
 		r.log.Error(err, "Failed to get existing spire oidc discovery provider deployment")
 		statusMgr.AddCondition(DeploymentAvailable, "SpireOIDCDeploymentGetFailed",
 			err.Error(),

--- a/pkg/controller/spire-oidc-discovery-provider/deployments_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/deployments_test.go
@@ -399,6 +399,7 @@ func TestReconcileDeployment(t *testing.T) {
 				Name:            "spire-spiffe-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,
@@ -437,6 +438,7 @@ func TestReconcileDeployment(t *testing.T) {
 				Name:            "spire-spiffe-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,
@@ -472,6 +474,7 @@ func TestReconcileDeployment(t *testing.T) {
 				Name:            "spire-spiffe-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,

--- a/pkg/controller/spire-oidc-discovery-provider/rbac.go
+++ b/pkg/controller/spire-oidc-discovery-provider/rbac.go
@@ -71,11 +71,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRole(ctx con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create external cert role")
@@ -143,11 +139,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRoleBinding(
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create external cert role binding")

--- a/pkg/controller/spire-oidc-discovery-provider/rbac.go
+++ b/pkg/controller/spire-oidc-discovery-provider/rbac.go
@@ -71,6 +71,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRole(ctx con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create external cert role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create external cert Role: %v", err),
@@ -80,14 +87,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRole(ctx con
 
 		r.log.Info("Created external cert Role", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -144,6 +143,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRoleBinding(
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create external cert role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create external cert RoleBinding: %v", err),
@@ -153,14 +159,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRoleBinding(
 
 		r.log.Info("Created external cert RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-oidc-discovery-provider/rbac.go
+++ b/pkg/controller/spire-oidc-discovery-provider/rbac.go
@@ -82,6 +82,14 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRole(ctx con
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("External cert Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -145,6 +153,14 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRoleBinding(
 
 		r.log.Info("Created external cert RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-oidc-discovery-provider/rbac_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/rbac_test.go
@@ -3,6 +3,7 @@ package spire_oidc_discovery_provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -39,11 +40,13 @@ func newTestStore() *testStore {
 }
 
 func (s *testStore) key(obj client.Object) string {
-	return obj.GetNamespace() + "/" + obj.GetName()
+	typeName := fmt.Sprintf("%T", obj)
+	return typeName + "/" + obj.GetNamespace() + "/" + obj.GetName()
 }
 
 func (s *testStore) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-	k := key.Namespace + "/" + key.Name
+	typeName := fmt.Sprintf("%T", obj)
+	k := typeName + "/" + key.Namespace + "/" + key.Name
 	stored, ok := s.objects[k]
 	if !ok {
 		return kerrors.NewNotFound(rbacv1.Resource(""), key.Name)
@@ -303,7 +306,7 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels:    map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 						},
 						Rules: []rbacv1.PolicyRule{
 							{
@@ -345,7 +348,7 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels:    map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: "ztwim.openshift.io/v1alpha1",
@@ -627,7 +630,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels:    map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa", Namespace: "old-ns"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old-role"},
@@ -662,7 +665,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels:    map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: "ztwim.openshift.io/v1alpha1",
@@ -813,7 +816,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireOIDCExternalCertRoleBindingName,
 						Namespace: utils.GetOperatorNamespace(),
-						Labels:    map[string]string{"old-label": "old-value"},
+						Labels:    map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa", Namespace: "old-ns"}},
 					RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old-role"},

--- a/pkg/controller/spire-oidc-discovery-provider/routes.go
+++ b/pkg/controller/spire-oidc-discovery-provider/routes.go
@@ -39,6 +39,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileRoute(ctx context.Contex
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				if err = r.ctrlClient.Create(ctx, route); err != nil {
+					if utils.IsResourceConflictOnCreate(err) {
+						conflictErr := utils.ResourceConflictError(route.GetNamespace(), route.GetName())
+						r.log.Error(conflictErr, "resource conflict detected")
+						statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
+							conflictErr.Error(), metav1.ConditionFalse)
+						return conflictErr
+					}
 					r.log.Error(err, "Failed to create route")
 					statusMgr.AddCondition(RouteAvailable, "ManagedRouteCreationFailed",
 						err.Error(),
@@ -59,11 +66,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileRoute(ctx context.Contex
 					metav1.ConditionFalse)
 				return err
 			}
-		} else if conflictErr := utils.CheckResourceConflict(&existingRoute); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
 		} else if checkRouteConflict(&existingRoute, route) {
 			r.log.Info("Found conflict in routes, updating route")
 			route.ResourceVersion = existingRoute.ResourceVersion

--- a/pkg/controller/spire-oidc-discovery-provider/routes.go
+++ b/pkg/controller/spire-oidc-discovery-provider/routes.go
@@ -59,6 +59,11 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileRoute(ctx context.Contex
 					metav1.ConditionFalse)
 				return err
 			}
+		} else if conflictErr := utils.CheckResourceConflict(&existingRoute); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
 		} else if checkRouteConflict(&existingRoute, route) {
 			r.log.Info("Found conflict in routes, updating route")
 			route.ResourceVersion = existingRoute.ResourceVersion

--- a/pkg/controller/spire-oidc-discovery-provider/routes.go
+++ b/pkg/controller/spire-oidc-discovery-provider/routes.go
@@ -39,11 +39,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileRoute(ctx context.Contex
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				if err = r.ctrlClient.Create(ctx, route); err != nil {
-					if utils.IsResourceConflictOnCreate(err) {
-						conflictErr := utils.ResourceConflictError(route.GetNamespace(), route.GetName())
-						r.log.Error(conflictErr, "resource conflict detected")
-						statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
-							conflictErr.Error(), metav1.ConditionFalse)
+					if conflictErr := utils.HandleCreateConflict(err, route, r.log, statusMgr, RouteAvailable); conflictErr != nil {
 						return conflictErr
 					}
 					r.log.Error(err, "Failed to create route")

--- a/pkg/controller/spire-oidc-discovery-provider/routes_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/routes_test.go
@@ -937,6 +937,7 @@ func TestReconcileRoute_UpdateSuccess(t *testing.T) {
 			Name:            "spire-oidc-discovery-provider",
 			Namespace:       utils.GetOperatorNamespace(),
 			ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "old.example.com", // Different host to trigger update
@@ -983,6 +984,7 @@ func TestReconcileRoute_UpdateError(t *testing.T) {
 			Name:            "spire-oidc-discovery-provider",
 			Namespace:       utils.GetOperatorNamespace(),
 			ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "old.example.com", // Different host to trigger update
@@ -1027,6 +1029,7 @@ func TestReconcileRoute_CreateOnlyMode(t *testing.T) {
 			Name:            "spire-oidc-discovery-provider",
 			Namespace:       utils.GetOperatorNamespace(),
 			ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "old.example.com", // Different host to trigger update

--- a/pkg/controller/spire-oidc-discovery-provider/service.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service.go
@@ -46,11 +46,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileService(ctx context.Cont
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service")

--- a/pkg/controller/spire-oidc-discovery-provider/service.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service.go
@@ -46,6 +46,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileService(ctx context.Cont
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service")
 			statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Service: %v", err),
@@ -58,14 +65,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileService(ctx context.Cont
 			"All Service resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-oidc-discovery-provider/service.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service.go
@@ -60,6 +60,14 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileService(ctx context.Cont
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Service exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-oidc-discovery-provider/service_account.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account.go
@@ -46,11 +46,7 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileServiceAccount(ctx conte
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAccountAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service account")

--- a/pkg/controller/spire-oidc-discovery-provider/service_account.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account.go
@@ -46,6 +46,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileServiceAccount(ctx conte
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.GetNamespace(), desired.GetName())
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service account")
 			statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ServiceAccount: %v", err),
@@ -58,14 +65,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileServiceAccount(ctx conte
 			"All ServiceAccount resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	// Resource exists - check ownership before proceeding
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-oidc-discovery-provider/service_account.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account.go
@@ -60,6 +60,14 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileServiceAccount(ctx conte
 		return nil
 	}
 
+	// Resource exists - check ownership before proceeding
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
@@ -178,6 +178,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -205,7 +206,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -234,7 +235,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -247,6 +248,28 @@ func TestReconcileServiceAccount(t *testing.T) {
 			},
 			expectError:  true,
 			expectUpdate: true,
+		},
+		{
+			name: "resource conflict - existing resource not managed by operator",
+			oidc: &v1alpha1.SpireOIDCDiscoveryProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingSA := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-spiffe-oidc-discovery-provider",
+						Namespace:       utils.GetOperatorNamespace(),
+						ResourceVersion: "123",
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if sa, ok := obj.(*corev1.ServiceAccount); ok {
+						*sa = *existingSA
+					}
+					return nil
+				}
+			},
+			expectError: true,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
@@ -305,7 +305,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
@@ -250,26 +250,17 @@ func TestReconcileServiceAccount(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name: "resource conflict - existing resource not managed by operator",
+			name: "resource conflict - create returns AlreadyExists",
 			oidc: &v1alpha1.SpireOIDCDiscoveryProvider{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
 			},
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
-				existingSA := &corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "spire-spiffe-oidc-discovery-provider",
-						Namespace:       utils.GetOperatorNamespace(),
-						ResourceVersion: "123",
-					},
-				}
-				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					if sa, ok := obj.(*corev1.ServiceAccount); ok {
-						*sa = *existingSA
-					}
-					return nil
-				}
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spire-spiffe-oidc-discovery-provider"))
+				fc.CreateReturns(kerrors.NewAlreadyExists(schema.GroupResource{Resource: "serviceaccounts"}, "spire-spiffe-oidc-discovery-provider"))
 			},
-			expectError: true,
+			expectError:  true,
+			expectCreate: true,
+			expectUpdate: false,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-oidc-discovery-provider/service_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_test.go
@@ -307,7 +307,7 @@ func TestReconcileService(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spire-oidc-discovery-provider/service_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_test.go
@@ -191,6 +191,7 @@ func TestReconcileService(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -218,7 +219,7 @@ func TestReconcileService(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -248,7 +249,7 @@ func TestReconcileService(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}

--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -56,11 +56,7 @@ func (r *SpireServerReconciler) reconcileSpireServerConfigMap(ctx context.Contex
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireServerConfigMap.Name, Namespace: spireServerConfigMap.Namespace}, &existingSpireServerCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireServerConfigMap); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(spireServerConfigMap.Namespace, spireServerConfigMap.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServerConfigMapAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, spireServerConfigMap, r.log, statusMgr, ServerConfigMapAvailable); conflictErr != nil {
 				return "", conflictErr
 			}
 			statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
@@ -130,11 +126,7 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerConfigMap(ctx con
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireControllerManagerConfigMap.Name, Namespace: spireControllerManagerConfigMap.Namespace}, &existingSpireControllerManagerCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireControllerManagerConfigMap); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(spireControllerManagerConfigMap.Namespace, spireControllerManagerConfigMap.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ControllerManagerConfigAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, spireControllerManagerConfigMap, r.log, statusMgr, ControllerManagerConfigAvailable); conflictErr != nil {
 				return "", conflictErr
 			}
 			r.log.Error(err, "failed to create spire controller manager config map")

--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -155,11 +155,14 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerConfigMap(ctx con
 						metav1.ConditionFalse)
 					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
 				}
+				r.log.Info("Updated ConfigMap with new config")
 			}
-			r.log.Info("Updated ConfigMap with new config")
 		}
 	} else {
-		r.log.Error(err, "failed to update spire controller manager config map")
+		r.log.Error(err, "failed to get spire controller manager config map")
+		statusMgr.AddCondition(ControllerManagerConfigAvailable, "SpireControllerManagerConfigMapGetFailed",
+			err.Error(),
+			metav1.ConditionFalse)
 		return "", err
 	}
 

--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -62,21 +62,29 @@ func (r *SpireServerReconciler) reconcileSpireServerConfigMap(ctx context.Contex
 			return "", fmt.Errorf("failed to create ConfigMap: %w", err)
 		}
 		r.log.Info("Created spire server ConfigMap")
-	} else if err == nil && (existingSpireServerCM.Data["server.conf"] != spireServerConfigMap.Data["server.conf"] ||
-		!equality.Semantic.DeepEqual(existingSpireServerCM.Labels, spireServerConfigMap.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping ConfigMap update due to create-only mode")
-		} else {
-			spireServerConfigMap.ResourceVersion = existingSpireServerCM.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireServerConfigMap); err != nil {
-				statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", fmt.Errorf("failed to update ConfigMap: %w", err)
-			}
-			r.log.Info("Updated ConfigMap with new config")
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSpireServerCM); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(ServerConfigMapAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return "", conflictErr
 		}
-	} else if err != nil {
+		if existingSpireServerCM.Data["server.conf"] != spireServerConfigMap.Data["server.conf"] ||
+			!equality.Semantic.DeepEqual(existingSpireServerCM.Labels, spireServerConfigMap.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping ConfigMap update due to create-only mode")
+			} else {
+				spireServerConfigMap.ResourceVersion = existingSpireServerCM.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireServerConfigMap); err != nil {
+					statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+				}
+				r.log.Info("Updated ConfigMap with new config")
+			}
+		}
+	} else {
 		statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
 			err.Error(),
 			metav1.ConditionFalse)
@@ -128,21 +136,29 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerConfigMap(ctx con
 			return "", fmt.Errorf("failed to create ConfigMap: %w", err)
 		}
 		r.log.Info("Created spire controller manager ConfigMap")
-	} else if err == nil && (existingSpireControllerManagerCM.Data["controller-manager-config.yaml"] != spireControllerManagerConfigMap.Data["controller-manager-config.yaml"] ||
-		!equality.Semantic.DeepEqual(existingSpireControllerManagerCM.Labels, spireControllerManagerConfigMap.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping spire controller manager ConfigMap update due to create-only mode")
-		} else {
-			spireControllerManagerConfigMap.ResourceVersion = existingSpireControllerManagerCM.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireControllerManagerConfigMap); err != nil {
-				statusMgr.AddCondition(ControllerManagerConfigAvailable, "SpireControllerManagerConfigMapGenerationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", fmt.Errorf("failed to update ConfigMap: %w", err)
-			}
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSpireControllerManagerCM); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(ControllerManagerConfigAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return "", conflictErr
 		}
-		r.log.Info("Updated ConfigMap with new config")
-	} else if err != nil {
+		if existingSpireControllerManagerCM.Data["controller-manager-config.yaml"] != spireControllerManagerConfigMap.Data["controller-manager-config.yaml"] ||
+			!equality.Semantic.DeepEqual(existingSpireControllerManagerCM.Labels, spireControllerManagerConfigMap.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping spire controller manager ConfigMap update due to create-only mode")
+			} else {
+				spireControllerManagerConfigMap.ResourceVersion = existingSpireControllerManagerCM.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireControllerManagerConfigMap); err != nil {
+					statusMgr.AddCondition(ControllerManagerConfigAvailable, "SpireControllerManagerConfigMapGenerationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+				}
+			}
+			r.log.Info("Updated ConfigMap with new config")
+		}
+	} else {
 		r.log.Error(err, "failed to update spire controller manager config map")
 		return "", err
 	}

--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -56,6 +56,13 @@ func (r *SpireServerReconciler) reconcileSpireServerConfigMap(ctx context.Contex
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireServerConfigMap.Name, Namespace: spireServerConfigMap.Namespace}, &existingSpireServerCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireServerConfigMap); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(spireServerConfigMap.Namespace, spireServerConfigMap.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServerConfigMapAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return "", conflictErr
+			}
 			statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
 				err.Error(),
 				metav1.ConditionFalse)
@@ -63,13 +70,7 @@ func (r *SpireServerReconciler) reconcileSpireServerConfigMap(ctx context.Contex
 		}
 		r.log.Info("Created spire server ConfigMap")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSpireServerCM); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(ServerConfigMapAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return "", conflictErr
-		}
-		if existingSpireServerCM.Data["server.conf"] != spireServerConfigMap.Data["server.conf"] ||
+		if existingSpireServerCM.Data[utils.SpireServerConfigKey] != spireServerConfigMap.Data[utils.SpireServerConfigKey] ||
 			!equality.Semantic.DeepEqual(existingSpireServerCM.Labels, spireServerConfigMap.Labels) {
 			if createOnlyMode {
 				r.log.Info("Skipping ConfigMap update due to create-only mode")
@@ -129,6 +130,13 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerConfigMap(ctx con
 	err = r.ctrlClient.Get(ctx, types.NamespacedName{Name: spireControllerManagerConfigMap.Name, Namespace: spireControllerManagerConfigMap.Namespace}, &existingSpireControllerManagerCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, spireControllerManagerConfigMap); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(spireControllerManagerConfigMap.Namespace, spireControllerManagerConfigMap.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ControllerManagerConfigAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return "", conflictErr
+			}
 			r.log.Error(err, "failed to create spire controller manager config map")
 			statusMgr.AddCondition(ControllerManagerConfigAvailable, "SpireControllerManagerConfigMapGenerationFailed",
 				err.Error(),
@@ -137,13 +145,7 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerConfigMap(ctx con
 		}
 		r.log.Info("Created spire controller manager ConfigMap")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSpireControllerManagerCM); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(ControllerManagerConfigAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return "", conflictErr
-		}
-		if existingSpireControllerManagerCM.Data["controller-manager-config.yaml"] != spireControllerManagerConfigMap.Data["controller-manager-config.yaml"] ||
+		if existingSpireControllerManagerCM.Data[utils.SpireControllerManagerConfigKey] != spireControllerManagerConfigMap.Data[utils.SpireControllerManagerConfigKey] ||
 			!equality.Semantic.DeepEqual(existingSpireControllerManagerCM.Labels, spireControllerManagerConfigMap.Labels) {
 			if createOnlyMode {
 				r.log.Info("Skipping spire controller manager ConfigMap update due to create-only mode")
@@ -231,7 +233,7 @@ func generateSpireServerConfigMap(config *v1alpha1.SpireServerSpec, ztwim *v1alp
 			Labels:    utils.SpireServerLabels(config.Labels),
 		},
 		Data: map[string]string{
-			"server.conf": string(confJSON),
+			utils.SpireServerConfigKey: string(confJSON),
 		},
 	}
 
@@ -559,7 +561,7 @@ func generateControllerManagerConfigMap(configYAML string) *corev1.ConfigMap {
 			Labels:    utils.SpireControllerManagerLabels(nil),
 		},
 		Data: map[string]string{
-			"controller-manager-config.yaml": configYAML,
+			utils.SpireControllerManagerConfigKey: configYAML,
 		},
 	}
 }

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -133,7 +133,7 @@ func TestGenerateSpireServerConfigMap(t *testing.T) {
 			}
 
 			// Verify config data exists
-			configData, exists := cm.Data["server.conf"]
+			configData, exists := cm.Data[utils.SpireServerConfigKey]
 			if !exists {
 				t.Fatal("Expected server.conf data to exist in ConfigMap")
 			}
@@ -356,7 +356,7 @@ func TestGenerateSpireServerConfigMapWithTTLFields(t *testing.T) {
 	}
 
 	// Verify config data exists
-	configData, exists := cm.Data["server.conf"]
+	configData, exists := cm.Data[utils.SpireServerConfigKey]
 	if !exists {
 		t.Fatal("Expected server.conf data to exist in ConfigMap")
 	}
@@ -619,7 +619,7 @@ func TestGenerateControllerManagerConfigMap(t *testing.T) {
 	}
 
 	// Check data
-	configData, exists := cm.Data["controller-manager-config.yaml"]
+	configData, exists := cm.Data[utils.SpireControllerManagerConfigKey]
 	if !exists {
 		t.Fatal("Expected controller-manager-config.yaml data to exist in ConfigMap")
 	}
@@ -1032,7 +1032,7 @@ func TestGenerateSpireServerConfigMapWithKeyTypes(t *testing.T) {
 			}
 
 			// Verify config data exists
-			configData, exists := cm.Data["server.conf"]
+			configData, exists := cm.Data[utils.SpireServerConfigKey]
 			if !exists {
 				t.Fatal("Expected server.conf data to exist in ConfigMap")
 			}
@@ -1391,7 +1391,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						ResourceVersion: "123",
 						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
-					Data: map[string]string{"server.conf": "old-config"},
+					Data: map[string]string{utils.SpireServerConfigKey: "old-config"},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cm, ok := obj.(*corev1.ConfigMap); ok {
@@ -1414,7 +1414,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						ResourceVersion: "123",
 						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
-					Data: map[string]string{"server.conf": "old-config"},
+					Data: map[string]string{utils.SpireServerConfigKey: "old-config"},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cm, ok := obj.(*corev1.ConfigMap); ok {
@@ -1437,7 +1437,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						ResourceVersion: "123",
 						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
-					Data: map[string]string{"server.conf": "old-config"},
+					Data: map[string]string{utils.SpireServerConfigKey: "old-config"},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cm, ok := obj.(*corev1.ConfigMap); ok {

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -1512,7 +1512,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, got %d", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})
@@ -1646,7 +1646,7 @@ func TestReconcileSpireControllerManagerConfigMap(t *testing.T) {
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, got %d", fakeClient.UpdateCallCount())
 			}
-			if !tt.expectUpdate && !tt.expectError && fakeClient.UpdateCallCount() != 0 {
+			if !tt.expectUpdate && fakeClient.UpdateCallCount() != 0 {
 				t.Error("Expected Update not to be called")
 			}
 		})

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -1389,6 +1389,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Data: map[string]string{"server.conf": "old-config"},
 				}
@@ -1411,6 +1412,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Data: map[string]string{"server.conf": "old-config"},
 				}
@@ -1433,6 +1435,7 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Data: map[string]string{"server.conf": "old-config"},
 				}
@@ -1560,6 +1563,7 @@ func TestReconcileSpireControllerManagerConfigMap(t *testing.T) {
 						Name:            "spire-controller-manager-config",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Data: map[string]string{"spire-controller-manager-config.yaml": "old-config"},
 				}
@@ -1582,6 +1586,7 @@ func TestReconcileSpireControllerManagerConfigMap(t *testing.T) {
 						Name:            "spire-controller-manager-config",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels:          map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Data: map[string]string{"spire-controller-manager-config.yaml": "old-config"},
 				}

--- a/pkg/controller/spire-server/rbac.go
+++ b/pkg/controller/spire-server/rbac.go
@@ -106,6 +106,13 @@ func (r *SpireServerReconciler) reconcileClusterRole(ctx context.Context, server
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRole exists, skipping update due to create-only mode", "name", desired.Name)
@@ -169,6 +176,13 @@ func (r *SpireServerReconciler) reconcileClusterRoleBinding(ctx context.Context,
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
+	}
+
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -236,6 +250,13 @@ func (r *SpireServerReconciler) reconcileSpireBundleRole(ctx context.Context, se
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -299,6 +320,13 @@ func (r *SpireServerReconciler) reconcileSpireBundleRoleBinding(ctx context.Cont
 
 		r.log.Info("Created RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -366,6 +394,13 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRole(ctx contex
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRole exists, skipping update due to create-only mode", "name", desired.Name)
@@ -429,6 +464,13 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRoleBinding(ctx
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
+	}
+
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -496,6 +538,13 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRole(ctx context.Context,
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -559,6 +608,13 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRoleBinding(ctx context.C
 
 		r.log.Info("Created RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -720,6 +776,13 @@ func (r *SpireServerReconciler) reconcileExternalCertRole(ctx context.Context, s
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("External cert Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -783,6 +846,13 @@ func (r *SpireServerReconciler) reconcileExternalCertRoleBinding(ctx context.Con
 
 		r.log.Info("Created external cert RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/rbac.go
+++ b/pkg/controller/spire-server/rbac.go
@@ -95,6 +95,13 @@ func (r *SpireServerReconciler) reconcileClusterRole(ctx context.Context, server
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create cluster role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ClusterRole: %v", err),
@@ -104,13 +111,6 @@ func (r *SpireServerReconciler) reconcileClusterRole(ctx context.Context, server
 
 		r.log.Info("Created ClusterRole", "name", desired.Name)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -167,6 +167,13 @@ func (r *SpireServerReconciler) reconcileClusterRoleBinding(ctx context.Context,
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create cluster role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ClusterRoleBinding: %v", err),
@@ -176,13 +183,6 @@ func (r *SpireServerReconciler) reconcileClusterRoleBinding(ctx context.Context,
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -239,6 +239,13 @@ func (r *SpireServerReconciler) reconcileSpireBundleRole(ctx context.Context, se
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create spire-bundle role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Bundle Role: %v", err),
@@ -248,13 +255,6 @@ func (r *SpireServerReconciler) reconcileSpireBundleRole(ctx context.Context, se
 
 		r.log.Info("Created Role", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -311,6 +311,13 @@ func (r *SpireServerReconciler) reconcileSpireBundleRoleBinding(ctx context.Cont
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create spire-bundle role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Bundle RoleBinding: %v", err),
@@ -320,13 +327,6 @@ func (r *SpireServerReconciler) reconcileSpireBundleRoleBinding(ctx context.Cont
 
 		r.log.Info("Created RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -383,6 +383,13 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRole(ctx contex
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create controller manager cluster role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Controller Manager ClusterRole: %v", err),
@@ -392,13 +399,6 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRole(ctx contex
 
 		r.log.Info("Created ClusterRole", "name", desired.Name)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -455,6 +455,13 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRoleBinding(ctx
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create controller manager cluster role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Controller Manager ClusterRoleBinding: %v", err),
@@ -464,13 +471,6 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRoleBinding(ctx
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -527,6 +527,13 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRole(ctx context.Context,
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create leader election role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Leader Election Role: %v", err),
@@ -536,13 +543,6 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRole(ctx context.Context,
 
 		r.log.Info("Created Role", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -599,6 +599,13 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRoleBinding(ctx context.C
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create leader election role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Leader Election RoleBinding: %v", err),
@@ -608,13 +615,6 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRoleBinding(ctx context.C
 
 		r.log.Info("Created RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -765,6 +765,13 @@ func (r *SpireServerReconciler) reconcileExternalCertRole(ctx context.Context, s
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create external cert role")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create external cert Role: %v", err),
@@ -774,13 +781,6 @@ func (r *SpireServerReconciler) reconcileExternalCertRole(ctx context.Context, s
 
 		r.log.Info("Created external cert Role", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -837,6 +837,13 @@ func (r *SpireServerReconciler) reconcileExternalCertRoleBinding(ctx context.Con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create external cert role binding")
 			statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create external cert RoleBinding: %v", err),
@@ -846,13 +853,6 @@ func (r *SpireServerReconciler) reconcileExternalCertRoleBinding(ctx context.Con
 
 		r.log.Info("Created external cert RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/rbac.go
+++ b/pkg/controller/spire-server/rbac.go
@@ -95,11 +95,7 @@ func (r *SpireServerReconciler) reconcileClusterRole(ctx context.Context, server
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create cluster role")
@@ -167,11 +163,7 @@ func (r *SpireServerReconciler) reconcileClusterRoleBinding(ctx context.Context,
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create cluster role binding")
@@ -239,11 +231,7 @@ func (r *SpireServerReconciler) reconcileSpireBundleRole(ctx context.Context, se
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create spire-bundle role")
@@ -311,11 +299,7 @@ func (r *SpireServerReconciler) reconcileSpireBundleRoleBinding(ctx context.Cont
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create spire-bundle role binding")
@@ -383,11 +367,7 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRole(ctx contex
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create controller manager cluster role")
@@ -455,11 +435,7 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRoleBinding(ctx
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create controller manager cluster role binding")
@@ -527,11 +503,7 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRole(ctx context.Context,
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create leader election role")
@@ -599,11 +571,7 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRoleBinding(ctx context.C
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create leader election role binding")
@@ -765,11 +733,7 @@ func (r *SpireServerReconciler) reconcileExternalCertRole(ctx context.Context, s
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create external cert role")
@@ -837,11 +801,7 @@ func (r *SpireServerReconciler) reconcileExternalCertRoleBinding(ctx context.Con
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, RBACAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create external cert role binding")

--- a/pkg/controller/spire-server/rbac_test.go
+++ b/pkg/controller/spire-server/rbac_test.go
@@ -554,6 +554,9 @@ func TestReconcileClusterRole(t *testing.T) {
 			if tt.expectCreate && fakeClient.CreateCallCount() != 1 {
 				t.Errorf("Expected Create to be called once, called %d times", fakeClient.CreateCallCount())
 			}
+			if !tt.expectCreate && !tt.expectError && fakeClient.CreateCallCount() != 0 {
+				t.Errorf("Expected Create not to be called, called %d times", fakeClient.CreateCallCount())
+			}
 			if tt.expectUpdate && fakeClient.UpdateCallCount() != 1 {
 				t.Errorf("Expected Update to be called once, called %d times", fakeClient.UpdateCallCount())
 			}

--- a/pkg/controller/spire-server/rbac_test.go
+++ b/pkg/controller/spire-server/rbac_test.go
@@ -499,24 +499,6 @@ func TestReconcileClusterRole(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name:   "resource conflict - existing resource not managed by operator",
-			server: createRBACTestServer(),
-			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
-				existingCR := &rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{Name: "spire-server", ResourceVersion: "123"},
-				}
-				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					if cr, ok := obj.(*rbacv1.ClusterRole); ok {
-						*cr = *existingCR
-					}
-					return nil
-				}
-			},
-			expectError:  true,
-			expectCreate: false,
-			expectUpdate: false,
-		},
-		{
 			name:           "set controller ref error",
 			server:         createRBACTestServer(),
 			setupClient:    func(fc *fakes.FakeCustomCtrlClient) {},

--- a/pkg/controller/spire-server/rbac_test.go
+++ b/pkg/controller/spire-server/rbac_test.go
@@ -3,6 +3,7 @@ package spire_server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -38,23 +39,24 @@ func newTestStore() *testStore {
 }
 
 func (s *testStore) key(obj client.Object) string {
+	typeName := fmt.Sprintf("%T", obj)
 	ns := obj.GetNamespace()
 	if ns == "" {
-		// For cluster-scoped resources
-		return obj.GetName()
+		return typeName + "/" + obj.GetName()
 	}
-	return ns + "/" + obj.GetName()
+	return typeName + "/" + ns + "/" + obj.GetName()
+}
+
+func (s *testStore) keyForGet(key client.ObjectKey, obj client.Object) string {
+	typeName := fmt.Sprintf("%T", obj)
+	if key.Namespace == "" {
+		return typeName + "/" + key.Name
+	}
+	return typeName + "/" + key.Namespace + "/" + key.Name
 }
 
 func (s *testStore) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-	ns := key.Namespace
-	if ns == "" {
-		ns = key.Name // For cluster-scoped resources
-	}
-	k := ns
-	if key.Namespace != "" {
-		k = key.Namespace + "/" + key.Name
-	}
+	k := s.keyForGet(key, obj)
 
 	stored, ok := s.objects[k]
 	if !ok {
@@ -456,7 +458,7 @@ func TestReconcileClusterRole(t *testing.T) {
 			server: createRBACTestServer(),
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
 				existingCR := &rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{Name: "spire-server", ResourceVersion: "123"},
+					ObjectMeta: metav1.ObjectMeta{Name: "spire-server", ResourceVersion: "123", Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cr, ok := obj.(*rbacv1.ClusterRole); ok {
@@ -482,7 +484,7 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -495,6 +497,24 @@ func TestReconcileClusterRole(t *testing.T) {
 			},
 			expectError:  true,
 			expectUpdate: true,
+		},
+		{
+			name:   "resource conflict - existing resource not managed by operator",
+			server: createRBACTestServer(),
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingCR := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{Name: "spire-server", ResourceVersion: "123"},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if cr, ok := obj.(*rbacv1.ClusterRole); ok {
+						*cr = *existingCR
+					}
+					return nil
+				}
+			},
+			expectError:  true,
+			expectCreate: false,
+			expectUpdate: false,
 		},
 		{
 			name:           "set controller ref error",
@@ -595,7 +615,7 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -622,7 +642,7 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -649,7 +669,7 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -762,7 +782,7 @@ func TestReconcileSpireBundleRole(t *testing.T) {
 						Name:            "spire-bundle",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -864,7 +884,7 @@ func TestReconcileSpireBundleRoleBinding(t *testing.T) {
 						Name:            "spire-bundle",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1008,7 +1028,7 @@ func TestReconcileControllerManagerClusterRole(t *testing.T) {
 			server: createRBACTestServer(),
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
 				existingCR := &rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{Name: "spire-controller-manager", ResourceVersion: "123"},
+					ObjectMeta: metav1.ObjectMeta{Name: "spire-controller-manager", ResourceVersion: "123", Labels: map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue}},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cr, ok := obj.(*rbacv1.ClusterRole); ok {
@@ -1116,7 +1136,7 @@ func TestReconcileControllerManagerClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1143,7 +1163,7 @@ func TestReconcileControllerManagerClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1252,7 +1272,7 @@ func TestReconcileLeaderElectionRole(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1280,7 +1300,7 @@ func TestReconcileLeaderElectionRole(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1389,7 +1409,7 @@ func TestReconcileLeaderElectionRoleBinding(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1417,7 +1437,7 @@ func TestReconcileLeaderElectionRoleBinding(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1723,6 +1743,7 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels:    map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 						},
 						Rules: []rbacv1.PolicyRule{{
 							APIGroups:     []string{""},
@@ -1757,6 +1778,7 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels:    map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 							OwnerReferences: []metav1.OwnerReference{{
 								APIVersion: "ztwim.openshift.io/v1alpha1",
 								Kind:       "SpireServer",
@@ -1796,6 +1818,10 @@ func TestReconcileExternalCertRole(t *testing.T) {
 			setupObjects: func() []client.Object {
 				desiredRole := getSpireServerExternalCertRole(nil)
 				desiredRole.Rules[0].ResourceNames = []string{"test-secret"}
+				if desiredRole.Labels == nil {
+					desiredRole.Labels = map[string]string{}
+				}
+				desiredRole.Labels["app.kubernetes.io/managed-by"] = "zero-trust-workload-identity-manager"
 				desiredRole.OwnerReferences = []metav1.OwnerReference{{
 					APIVersion: "ztwim.openshift.io/v1alpha1",
 					Kind:       "SpireServer",
@@ -1859,6 +1885,7 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels:    map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 						},
 						Rules: []rbacv1.PolicyRule{{
 							APIGroups:     []string{""},
@@ -1876,6 +1903,7 @@ func TestReconcileExternalCertRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireServerExternalCertRoleName,
 						Namespace: utils.GetOperatorNamespace(),
+						Labels:    map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{{
 						APIGroups:     []string{""},
@@ -1972,7 +2000,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old": "label"},
+							Labels:    map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old"},
@@ -1993,7 +2021,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old": "label"},
+							Labels:    map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 							OwnerReferences: []metav1.OwnerReference{{
 								APIVersion: "ztwim.openshift.io/v1alpha1",
 								Kind:       "SpireServer",
@@ -2026,6 +2054,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 			name: "no update when rolebinding is already up to date",
 			setupObjects: func() []client.Object {
 				desiredRB := getSpireServerExternalCertRoleBinding(nil)
+				if desiredRB.Labels == nil {
+					desiredRB.Labels = map[string]string{}
+				}
+				desiredRB.Labels["app.kubernetes.io/managed-by"] = "zero-trust-workload-identity-manager"
 				desiredRB.OwnerReferences = []metav1.OwnerReference{{
 					APIVersion: "ztwim.openshift.io/v1alpha1",
 					Kind:       "SpireServer",
@@ -2085,6 +2117,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels:    map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old"},
@@ -2098,6 +2131,7 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireServerExternalCertRoleBindingName,
 						Namespace: utils.GetOperatorNamespace(),
+						Labels:    map[string]string{utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa"}},
 					RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old"},

--- a/pkg/controller/spire-server/routes.go
+++ b/pkg/controller/spire-server/routes.go
@@ -108,6 +108,13 @@ func (r *SpireServerReconciler) reconcileRoute(ctx context.Context, server *v1al
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				if err = r.ctrlClient.Create(ctx, route); err != nil {
+					if utils.IsResourceConflictOnCreate(err) {
+						conflictErr := utils.ResourceConflictError(route.Namespace, route.Name)
+						r.log.Error(conflictErr, "resource conflict detected")
+						statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
+							conflictErr.Error(), metav1.ConditionFalse)
+						return conflictErr
+					}
 					r.log.Error(err, "Failed to create federation route")
 					statusMgr.AddCondition(RouteAvailable, "FederationRouteCreationFailed",
 						err.Error(),
@@ -128,11 +135,6 @@ func (r *SpireServerReconciler) reconcileRoute(ctx context.Context, server *v1al
 					metav1.ConditionFalse)
 				return err
 			}
-		} else if conflictErr := utils.CheckResourceConflict(&existingRoute); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
 		} else if checkFederationRouteConflict(&existingRoute, route) {
 			if createOnlyMode {
 				r.log.Info("Skipping federation route update due to create-only mode")

--- a/pkg/controller/spire-server/routes.go
+++ b/pkg/controller/spire-server/routes.go
@@ -108,11 +108,7 @@ func (r *SpireServerReconciler) reconcileRoute(ctx context.Context, server *v1al
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				if err = r.ctrlClient.Create(ctx, route); err != nil {
-					if utils.IsResourceConflictOnCreate(err) {
-						conflictErr := utils.ResourceConflictError(route.Namespace, route.Name)
-						r.log.Error(conflictErr, "resource conflict detected")
-						statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
-							conflictErr.Error(), metav1.ConditionFalse)
+					if conflictErr := utils.HandleCreateConflict(err, route, r.log, statusMgr, RouteAvailable); conflictErr != nil {
 						return conflictErr
 					}
 					r.log.Error(err, "Failed to create federation route")

--- a/pkg/controller/spire-server/routes.go
+++ b/pkg/controller/spire-server/routes.go
@@ -128,6 +128,11 @@ func (r *SpireServerReconciler) reconcileRoute(ctx context.Context, server *v1al
 					metav1.ConditionFalse)
 				return err
 			}
+		} else if conflictErr := utils.CheckResourceConflict(&existingRoute); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
 		} else if checkFederationRouteConflict(&existingRoute, route) {
 			if createOnlyMode {
 				r.log.Info("Skipping federation route update due to create-only mode")

--- a/pkg/controller/spire-server/routes_test.go
+++ b/pkg/controller/spire-server/routes_test.go
@@ -470,7 +470,7 @@ func TestReconcileRoute(t *testing.T) {
 						Name:            "spire-server-federation",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: routev1.RouteSpec{Host: "old-host"},
 				}
@@ -498,7 +498,7 @@ func TestReconcileRoute(t *testing.T) {
 						Name:            "spire-server-federation",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: routev1.RouteSpec{Host: "old-host"},
 				}
@@ -526,7 +526,7 @@ func TestReconcileRoute(t *testing.T) {
 						Name:            "spire-server-federation",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels:          map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: routev1.RouteSpec{Host: "old-host"},
 				}

--- a/pkg/controller/spire-server/service.go
+++ b/pkg/controller/spire-server/service.go
@@ -64,6 +64,13 @@ func (r *SpireServerReconciler) reconcileSpireServerService(ctx context.Context,
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service")
 			statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Service: %v", err),
@@ -73,13 +80,6 @@ func (r *SpireServerReconciler) reconcileSpireServerService(ctx context.Context,
 
 		r.log.Info("Created Service", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update
@@ -154,6 +154,13 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerService(ctx conte
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create controller manager service")
 			statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create Controller Manager Service: %v", err),
@@ -163,13 +170,6 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerService(ctx conte
 
 		r.log.Info("Created Service", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/service.go
+++ b/pkg/controller/spire-server/service.go
@@ -64,11 +64,7 @@ func (r *SpireServerReconciler) reconcileSpireServerService(ctx context.Context,
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service")
@@ -154,11 +150,7 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerService(ctx conte
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create controller manager service")

--- a/pkg/controller/spire-server/service.go
+++ b/pkg/controller/spire-server/service.go
@@ -75,6 +75,13 @@ func (r *SpireServerReconciler) reconcileSpireServerService(ctx context.Context,
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Service exists, skipping update due to create-only mode", "name", desired.Name)
@@ -156,6 +163,13 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerService(ctx conte
 
 		r.log.Info("Created Service", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/service_account.go
+++ b/pkg/controller/spire-server/service_account.go
@@ -46,6 +46,13 @@ func (r *SpireServerReconciler) reconcileServiceAccount(ctx context.Context, ser
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create service account")
 			statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ServiceAccount: %v", err),
@@ -58,13 +65,6 @@ func (r *SpireServerReconciler) reconcileServiceAccount(ctx context.Context, ser
 			"All ServiceAccount resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/service_account.go
+++ b/pkg/controller/spire-server/service_account.go
@@ -46,11 +46,7 @@ func (r *SpireServerReconciler) reconcileServiceAccount(ctx context.Context, ser
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ServiceAccountAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create service account")

--- a/pkg/controller/spire-server/service_account.go
+++ b/pkg/controller/spire-server/service_account.go
@@ -60,6 +60,13 @@ func (r *SpireServerReconciler) reconcileServiceAccount(ctx context.Context, ser
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-server/service_account_test.go
+++ b/pkg/controller/spire-server/service_account_test.go
@@ -167,6 +167,9 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -196,7 +199,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -226,7 +229,7 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -239,6 +242,30 @@ func TestReconcileServiceAccount(t *testing.T) {
 			},
 			expectError:  true,
 			expectUpdate: true,
+		},
+		{
+			name: "resource conflict - existing resource not managed by operator",
+			server: &v1alpha1.SpireServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingSA := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-server",
+						Namespace:       utils.GetOperatorNamespace(),
+						ResourceVersion: "123",
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if sa, ok := obj.(*corev1.ServiceAccount); ok {
+						*sa = *existingSA
+					}
+					return nil
+				}
+			},
+			expectError:  true,
+			expectCreate: false,
+			expectUpdate: false,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-server/service_account_test.go
+++ b/pkg/controller/spire-server/service_account_test.go
@@ -244,27 +244,16 @@ func TestReconcileServiceAccount(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name: "resource conflict - existing resource not managed by operator",
+			name: "resource conflict - create returns AlreadyExists",
 			server: &v1alpha1.SpireServer{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
 			},
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
-				existingSA := &corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "spire-server",
-						Namespace:       utils.GetOperatorNamespace(),
-						ResourceVersion: "123",
-					},
-				}
-				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					if sa, ok := obj.(*corev1.ServiceAccount); ok {
-						*sa = *existingSA
-					}
-					return nil
-				}
+				fc.GetReturns(kerrors.NewNotFound(schema.GroupResource{}, "spire-server"))
+				fc.CreateReturns(kerrors.NewAlreadyExists(schema.GroupResource{Resource: "serviceaccounts"}, "spire-server"))
 			},
 			expectError:  true,
-			expectCreate: false,
+			expectCreate: true,
 			expectUpdate: false,
 		},
 		{

--- a/pkg/controller/spire-server/service_test.go
+++ b/pkg/controller/spire-server/service_test.go
@@ -326,7 +326,7 @@ func TestReconcileSpireServerService(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -357,7 +357,7 @@ func TestReconcileSpireServerService(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -388,7 +388,7 @@ func TestReconcileSpireServerService(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -513,7 +513,7 @@ func TestReconcileSpireControllerManagerService(t *testing.T) {
 						Name:            "spire-controller-manager-webhook",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2"},
 				}
@@ -544,7 +544,7 @@ func TestReconcileSpireControllerManagerService(t *testing.T) {
 						Name:            "spire-controller-manager-webhook",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2"},
 				}

--- a/pkg/controller/spire-server/statefulset.go
+++ b/pkg/controller/spire-server/statefulset.go
@@ -44,6 +44,13 @@ func (r *SpireServerReconciler) reconcileStatefulSet(ctx context.Context, server
 	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}, &existingSTS)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, sts); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(sts.Namespace, sts.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(StatefulSetAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetCreationFailed",
 				err.Error(),
 				metav1.ConditionFalse)
@@ -51,12 +58,6 @@ func (r *SpireServerReconciler) reconcileStatefulSet(ctx context.Context, server
 		}
 		r.log.Info("Created spire server StatefulSet")
 	} else if err == nil {
-		if conflictErr := utils.CheckResourceConflict(&existingSTS); conflictErr != nil {
-			r.log.Error(conflictErr, "resource conflict detected")
-			statusMgr.AddCondition(StatefulSetAvailable, v1alpha1.ReasonResourceConflict,
-				conflictErr.Error(), metav1.ConditionFalse)
-			return conflictErr
-		}
 		if needsUpdate(existingSTS, *sts) {
 			if createOnlyMode {
 				r.log.Info("Skipping StatefulSet update due to create-only mode")

--- a/pkg/controller/spire-server/statefulset.go
+++ b/pkg/controller/spire-server/statefulset.go
@@ -50,20 +50,28 @@ func (r *SpireServerReconciler) reconcileStatefulSet(ctx context.Context, server
 			return fmt.Errorf("failed to create StatefulSet: %w", err)
 		}
 		r.log.Info("Created spire server StatefulSet")
-	} else if err == nil && needsUpdate(existingSTS, *sts) {
-		if createOnlyMode {
-			r.log.Info("Skipping StatefulSet update due to create-only mode")
-		} else {
-			sts.ResourceVersion = existingSTS.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, sts); err != nil {
-				statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetUpdateFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return fmt.Errorf("failed to update StatefulSet: %w", err)
-			}
-			r.log.Info("Updated spire server StatefulSet")
+	} else if err == nil {
+		if conflictErr := utils.CheckResourceConflict(&existingSTS); conflictErr != nil {
+			r.log.Error(conflictErr, "resource conflict detected")
+			statusMgr.AddCondition(StatefulSetAvailable, v1alpha1.ReasonResourceConflict,
+				conflictErr.Error(), metav1.ConditionFalse)
+			return conflictErr
 		}
-	} else if err != nil {
+		if needsUpdate(existingSTS, *sts) {
+			if createOnlyMode {
+				r.log.Info("Skipping StatefulSet update due to create-only mode")
+			} else {
+				sts.ResourceVersion = existingSTS.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, sts); err != nil {
+					statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetUpdateFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return fmt.Errorf("failed to update StatefulSet: %w", err)
+				}
+				r.log.Info("Updated spire server StatefulSet")
+			}
+		}
+	} else {
 		r.log.Error(err, "failed to get spire server stateful set resource")
 		statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetGetFailed",
 			err.Error(),

--- a/pkg/controller/spire-server/statefulset.go
+++ b/pkg/controller/spire-server/statefulset.go
@@ -44,11 +44,7 @@ func (r *SpireServerReconciler) reconcileStatefulSet(ctx context.Context, server
 	err := r.ctrlClient.Get(ctx, types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}, &existingSTS)
 	if err != nil && kerrors.IsNotFound(err) {
 		if err = r.ctrlClient.Create(ctx, sts); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(sts.Namespace, sts.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(StatefulSetAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, sts, r.log, statusMgr, StatefulSetAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetCreationFailed",

--- a/pkg/controller/spire-server/statefulset_test.go
+++ b/pkg/controller/spire-server/statefulset_test.go
@@ -929,7 +929,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 				existingSts := &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "spire-server", Namespace: utils.GetOperatorNamespace(),
-						ResourceVersion: "123", Labels: map[string]string{"old": "label"},
+						ResourceVersion: "123", Labels: map[string]string{"old": "label", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
 				}

--- a/pkg/controller/spire-server/webhook.go
+++ b/pkg/controller/spire-server/webhook.go
@@ -46,11 +46,7 @@ func (r *SpireServerReconciler) reconcileWebhook(ctx context.Context, server *v1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
-			if utils.IsResourceConflictOnCreate(err) {
-				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
-				r.log.Error(conflictErr, "resource conflict detected")
-				statusMgr.AddCondition(ValidatingWebhookAvailable, v1alpha1.ReasonResourceConflict,
-					conflictErr.Error(), metav1.ConditionFalse)
+			if conflictErr := utils.HandleCreateConflict(err, desired, r.log, statusMgr, ValidatingWebhookAvailable); conflictErr != nil {
 				return conflictErr
 			}
 			r.log.Error(err, "failed to create validating webhook")

--- a/pkg/controller/spire-server/webhook.go
+++ b/pkg/controller/spire-server/webhook.go
@@ -46,6 +46,13 @@ func (r *SpireServerReconciler) reconcileWebhook(ctx context.Context, server *v1
 
 		// Resource doesn't exist, create it
 		if err := r.ctrlClient.Create(ctx, desired); err != nil {
+			if utils.IsResourceConflictOnCreate(err) {
+				conflictErr := utils.ResourceConflictError(desired.Namespace, desired.Name)
+				r.log.Error(conflictErr, "resource conflict detected")
+				statusMgr.AddCondition(ValidatingWebhookAvailable, v1alpha1.ReasonResourceConflict,
+					conflictErr.Error(), metav1.ConditionFalse)
+				return conflictErr
+			}
 			r.log.Error(err, "failed to create validating webhook")
 			statusMgr.AddCondition(ValidatingWebhookAvailable, v1alpha1.ReasonFailed,
 				fmt.Sprintf("Failed to create ValidatingWebhookConfiguration: %v", err),
@@ -58,13 +65,6 @@ func (r *SpireServerReconciler) reconcileWebhook(ctx context.Context, server *v1
 			"All ValidatingWebhookConfiguration resources available",
 			metav1.ConditionTrue)
 		return nil
-	}
-
-	if err := utils.CheckResourceConflict(existing); err != nil {
-		r.log.Error(err, "resource conflict detected")
-		statusMgr.AddCondition(ValidatingWebhookAvailable, v1alpha1.ReasonResourceConflict,
-			err.Error(), metav1.ConditionFalse)
-		return err
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/webhook.go
+++ b/pkg/controller/spire-server/webhook.go
@@ -60,6 +60,13 @@ func (r *SpireServerReconciler) reconcileWebhook(ctx context.Context, server *v1
 		return nil
 	}
 
+	if err := utils.CheckResourceConflict(existing); err != nil {
+		r.log.Error(err, "resource conflict detected")
+		statusMgr.AddCondition(ValidatingWebhookAvailable, v1alpha1.ReasonResourceConflict,
+			err.Error(), metav1.ConditionFalse)
+		return err
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ValidatingWebhookConfiguration exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-server/webhook_test.go
+++ b/pkg/controller/spire-server/webhook_test.go
@@ -166,7 +166,7 @@ func TestReconcileWebhook(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager-webhook",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -195,7 +195,7 @@ func TestReconcileWebhook(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager-webhook",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -224,7 +224,7 @@ func TestReconcileWebhook(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager-webhook",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels:          map[string]string{"old-label": "old-value", utils.AppManagedByLabelKey: utils.AppManagedByLabelValue},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -83,6 +83,11 @@ const (
 	WorkloadAttestorVerificationTypeAuto     = "auto"
 	WorkloadAttestorVerificationTypeHostCert = "hostCert"
 
+	// ConfigMap Data Keys
+	SpireAgentConfigKey             = "agent.conf"
+	SpireServerConfigKey            = "server.conf"
+	SpireControllerManagerConfigKey = "controller-manager-config.yaml"
+
 	// Default Kubelet CA Paths (for OpenShift clusters)
 	// These are used as defaults for 'auto' mode when no explicit paths are provided.
 	DefaultKubeletCABasePath = "/etc/kubernetes"

--- a/pkg/controller/utils/resource_ownership.go
+++ b/pkg/controller/utils/resource_ownership.go
@@ -3,9 +3,17 @@ package utils
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ConditionRecorder is satisfied by status.Manager and allows HandleCreateConflict
+// to record conditions without importing the status package.
+type ConditionRecorder interface {
+	AddCondition(conditionType, reason, message string, status metav1.ConditionStatus)
+}
 
 // CheckResourceConflict verifies that an existing resource is managed by the operator
 // by checking the managed-by label. Returns an error if the resource exists but does not
@@ -16,6 +24,20 @@ func CheckResourceConflict(existing client.Object) error {
 		return nil
 	}
 	return ResourceConflictError(existing.GetNamespace(), existing.GetName())
+}
+
+// HandleCreateConflict checks if a Create error is an AlreadyExists conflict and, if so,
+// logs the error, records a ResourceConflict condition, and returns the conflict error.
+// Returns nil if the error is not an AlreadyExists conflict.
+func HandleCreateConflict(err error, obj client.Object, log logr.Logger, recorder ConditionRecorder, conditionType string) error {
+	if !kerrors.IsAlreadyExists(err) {
+		return nil
+	}
+	conflictErr := ResourceConflictError(obj.GetNamespace(), obj.GetName())
+	log.Error(conflictErr, "resource conflict detected")
+	recorder.AddCondition(conditionType, "ResourceConflict",
+		conflictErr.Error(), metav1.ConditionFalse)
+	return conflictErr
 }
 
 // IsResourceConflictOnCreate checks if a Create error is an AlreadyExists error,

--- a/pkg/controller/utils/resource_ownership.go
+++ b/pkg/controller/utils/resource_ownership.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CheckResourceConflict verifies that an existing resource is managed by the operator
+// by checking the managed-by label. Returns an error if the resource exists but does not
+// have the operator's managed-by label, indicating a naming conflict with a pre-existing resource.
+func CheckResourceConflict(existing client.Object) error {
+	labels := existing.GetLabels()
+	if labels != nil && labels[AppManagedByLabelKey] == AppManagedByLabelValue {
+		return nil
+	}
+	ns := existing.GetNamespace()
+	name := existing.GetName()
+	if ns != "" {
+		return fmt.Errorf("resource %s/%s already exists but is not managed by the operator", ns, name)
+	}
+	return fmt.Errorf("resource %s already exists but is not managed by the operator", name)
+}

--- a/pkg/controller/utils/resource_ownership.go
+++ b/pkg/controller/utils/resource_ownership.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -14,10 +15,20 @@ func CheckResourceConflict(existing client.Object) error {
 	if labels != nil && labels[AppManagedByLabelKey] == AppManagedByLabelValue {
 		return nil
 	}
-	ns := existing.GetNamespace()
-	name := existing.GetName()
-	if ns != "" {
-		return fmt.Errorf("resource %s/%s already exists but is not managed by the operator", ns, name)
+	return ResourceConflictError(existing.GetNamespace(), existing.GetName())
+}
+
+// IsResourceConflictOnCreate checks if a Create error is an AlreadyExists error,
+// which indicates a naming conflict with a pre-existing resource not visible in
+// the operator's label-filtered cache.
+func IsResourceConflictOnCreate(err error) bool {
+	return kerrors.IsAlreadyExists(err)
+}
+
+// ResourceConflictError returns a formatted error for a resource conflict.
+func ResourceConflictError(namespace, name string) error {
+	if namespace != "" {
+		return fmt.Errorf("resource %s/%s already exists but is not managed by the operator", namespace, name)
 	}
 	return fmt.Errorf("resource %s already exists but is not managed by the operator", name)
 }

--- a/pkg/controller/utils/resource_ownership_test.go
+++ b/pkg/controller/utils/resource_ownership_test.go
@@ -1,0 +1,113 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCheckResourceConflict(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  *corev1.ConfigMap
+		expectErr bool
+		errSubstr string
+	}{
+		{
+			name: "resource with managed-by label - no conflict",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spire-server",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						AppManagedByLabelKey: AppManagedByLabelValue,
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "resource with managed-by label and other labels - no conflict",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spire-server",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						AppManagedByLabelKey:         AppManagedByLabelValue,
+						"app.kubernetes.io/instance": "cluster",
+						"custom-label":               "value",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "resource with no labels - conflict",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spire-server",
+					Namespace: "test-ns",
+				},
+			},
+			expectErr: true,
+			errSubstr: "test-ns/spire-server already exists but is not managed by the operator",
+		},
+		{
+			name: "resource with different managed-by value - conflict",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spire-server",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						AppManagedByLabelKey: "some-other-operator",
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "already exists but is not managed by the operator",
+		},
+		{
+			name: "resource with labels but no managed-by - conflict",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spire-server",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "spire-server",
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "already exists but is not managed by the operator",
+		},
+		{
+			name: "cluster-scoped resource without label - conflict message has no namespace",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spire-server",
+				},
+			},
+			expectErr: true,
+			errSubstr: "resource spire-server already exists but is not managed by the operator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckResourceConflict(tt.existing)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				} else if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error to contain %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/utils/resource_ownership_test.go
+++ b/pkg/controller/utils/resource_ownership_test.go
@@ -1,11 +1,14 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestCheckResourceConflict(t *testing.T) {
@@ -107,6 +110,44 @@ func TestCheckResourceConflict(t *testing.T) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
 				}
+			}
+		})
+	}
+}
+
+func TestIsResourceConflictOnCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "AlreadyExists error is a conflict",
+			err:      kerrors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "configmaps"}, "spire-server"),
+			expected: true,
+		},
+		{
+			name:     "NotFound error is not a conflict",
+			err:      kerrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "spire-server"),
+			expected: false,
+		},
+		{
+			name:     "generic error is not a conflict",
+			err:      fmt.Errorf("connection refused"),
+			expected: false,
+		},
+		{
+			name:     "nil error is not a conflict",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsResourceConflictOnCreate(tt.err)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `CheckResourceConflict` utility that validates the `app.kubernetes.io/managed-by` label before any resource update
- Adds `ReasonResourceConflict` condition constant for status reporting
- Integrates conflict checks into all 4 controllers
- Updates all existing tests with managed-by labels and adds conflict detection test cases

## Behavior

- **Day 1 (Installation):** If a resource with the same name already exists and is not labeled as operator-managed, the operator reports a `ResourceConflict` condition and refuses to overwrite it
- **Day 2 (Operations):** Normal updates proceed if the managed-by label is present. If the label is removed, the operator detects the conflict on the next reconcile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "ResourceConflict" condition reason to surface create-time resource conflicts.

* **Bug Fixes**
  * Controllers detect create-time ownership/conflicts, set ResourceConflict conditions, and stop on conflicts instead of proceeding.
  * Preserve managed-by labels and avoid unintended updates to non-managed resources.
  * Standardize ConfigMap data keys for agent/server/controller-manager configs.

* **Tests**
  * Expanded tests for conflict detection, managed-label preservation, and standardized config-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->