### PR TITLE
SPIRE-506: Fix stale ResourceVersion race condition causing 409 Conflicts

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -676,6 +676,7 @@ spec:
                         - linux
               containers:
               - args:
+                - --leader-elect
                 - --health-probe-bind-address=:8081
                 - --v=$(OPERATOR_LOG_LEVEL)
                 - --metrics-bind-address=$(METRICS_BIND_ADDRESS)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,6 +58,7 @@ spec:
       - command:
         - /usr/bin/zero-trust-workload-identity-manager
         args:
+          - --leader-elect
           - --health-probe-bind-address=:8081
           - --v=$(OPERATOR_LOG_LEVEL)
           - --metrics-bind-address=$(METRICS_BIND_ADDRESS)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -157,12 +157,9 @@ func (c *customCtrlClientImpl) UpdateWithRetry(
 			return fmt.Errorf("failed to fetch latest %q for update: %w", key, err)
 		}
 		obj.SetResourceVersion(current.GetResourceVersion())
-		if err := c.Client.Update(ctx, obj, opts...); err != nil {
-			return fmt.Errorf("failed to update %q resource: %w", key, err)
-		}
-		return nil
+		return c.Client.Update(ctx, obj, opts...)
 	}); err != nil {
-		return err
+		return fmt.Errorf("failed to update %q resource: %w", key, err)
 	}
 
 	return nil
@@ -178,12 +175,9 @@ func (c *customCtrlClientImpl) StatusUpdateWithRetry(
 			return fmt.Errorf("failed to fetch latest %q for update: %w", key, err)
 		}
 		obj.SetResourceVersion(current.GetResourceVersion())
-		if err := c.Client.Status().Update(ctx, obj, opts...); err != nil {
-			return fmt.Errorf("failed to update %q resource: %w", key, err)
-		}
-		return nil
+		return c.Client.Status().Update(ctx, obj, opts...)
 	}); err != nil {
-		return err
+		return fmt.Errorf("failed to update %q status: %w", key, err)
 	}
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -169,13 +169,27 @@ func (c *customCtrlClientImpl) StatusUpdateWithRetry(
 	ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption,
 ) error {
 	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	attempt := 0
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		attempt++
 		current := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(client.Object)
 		if err := c.Client.Get(ctx, key, current); err != nil {
 			return fmt.Errorf("failed to fetch latest %q for update: %w", key, err)
 		}
-		obj.SetResourceVersion(current.GetResourceVersion())
-		return c.Client.Status().Update(ctx, obj, opts...)
+		fetchedRV := current.GetResourceVersion()
+		objRVBefore := obj.GetResourceVersion()
+		obj.SetResourceVersion(fetchedRV)
+		fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d objRV_before=%s cacheRV=%s\n",
+			key, attempt, objRVBefore, fetchedRV)
+		err := c.Client.Status().Update(ctx, obj, opts...)
+		if err != nil {
+			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d FAILED: %v\n",
+				key, attempt, err)
+		} else {
+			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d OK newRV=%s\n",
+				key, attempt, obj.GetResourceVersion())
+		}
+		return err
 	}); err != nil {
 		return fmt.Errorf("failed to update %q status: %w", key, err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -176,24 +176,51 @@ func (c *customCtrlClientImpl) StatusUpdateWithRetry(
 		if err := c.Client.Get(ctx, key, current); err != nil {
 			return fmt.Errorf("failed to fetch latest %q for update: %w", key, err)
 		}
-		fetchedRV := current.GetResourceVersion()
-		objRVBefore := obj.GetResourceVersion()
-		obj.SetResourceVersion(fetchedRV)
-		fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d objRV_before=%s cacheRV=%s\n",
-			key, attempt, objRVBefore, fetchedRV)
+		cacheRV := current.GetResourceVersion()
+		obj.SetResourceVersion(cacheRV)
+		condSummary := extractConditionSummary(obj)
+		fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d cacheRV=%s conditions=[%s]\n",
+			key, attempt, cacheRV, condSummary)
 		err := c.Client.Status().Update(ctx, obj, opts...)
 		if err != nil {
-			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d FAILED: %v\n",
-				key, attempt, err)
+			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d FAILED: %v\n", key, attempt, err)
 		} else {
-			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d OK newRV=%s\n",
-				key, attempt, obj.GetResourceVersion())
+			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d OK newRV=%s\n", key, attempt, obj.GetResourceVersion())
 		}
 		return err
 	}); err != nil {
 		return fmt.Errorf("failed to update %q status: %w", key, err)
 	}
 	return nil
+}
+
+func extractConditionSummary(obj client.Object) string {
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	statusField := v.FieldByName("Status")
+	if !statusField.IsValid() {
+		return "no-status-field"
+	}
+	var conditions []interface{}
+	condField := statusField.FieldByName("Conditions")
+	if !condField.IsValid() {
+		csField := statusField.FieldByName("ConditionalStatus")
+		if csField.IsValid() {
+			condField = csField.FieldByName("Conditions")
+		}
+	}
+	if !condField.IsValid() {
+		return "no-conditions-field"
+	}
+	for i := 0; i < condField.Len(); i++ {
+		c := condField.Index(i)
+		cType := c.FieldByName("Type").String()
+		cStatus := c.FieldByName("Status").String()
+		conditions = append(conditions, fmt.Sprintf("%s=%s", cType, cStatus))
+	}
+	return fmt.Sprintf("%v", conditions)
 }
 
 func (c *customCtrlClientImpl) StatusUpdate(

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -169,58 +169,17 @@ func (c *customCtrlClientImpl) StatusUpdateWithRetry(
 	ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption,
 ) error {
 	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-	attempt := 0
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		attempt++
 		current := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(client.Object)
 		if err := c.Client.Get(ctx, key, current); err != nil {
 			return fmt.Errorf("failed to fetch latest %q for update: %w", key, err)
 		}
-		cacheRV := current.GetResourceVersion()
-		obj.SetResourceVersion(cacheRV)
-		condSummary := extractConditionSummary(obj)
-		fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d cacheRV=%s conditions=[%s]\n",
-			key, attempt, cacheRV, condSummary)
-		err := c.Client.Status().Update(ctx, obj, opts...)
-		if err != nil {
-			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d FAILED: %v\n", key, attempt, err)
-		} else {
-			fmt.Printf("DIAG StatusUpdateWithRetry: key=%s attempt=%d OK newRV=%s\n", key, attempt, obj.GetResourceVersion())
-		}
-		return err
+		obj.SetResourceVersion(current.GetResourceVersion())
+		return c.Client.Status().Update(ctx, obj, opts...)
 	}); err != nil {
 		return fmt.Errorf("failed to update %q status: %w", key, err)
 	}
 	return nil
-}
-
-func extractConditionSummary(obj client.Object) string {
-	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
-	statusField := v.FieldByName("Status")
-	if !statusField.IsValid() {
-		return "no-status-field"
-	}
-	var conditions []interface{}
-	condField := statusField.FieldByName("Conditions")
-	if !condField.IsValid() {
-		csField := statusField.FieldByName("ConditionalStatus")
-		if csField.IsValid() {
-			condField = csField.FieldByName("Conditions")
-		}
-	}
-	if !condField.IsValid() {
-		return "no-conditions-field"
-	}
-	for i := 0; i < condField.Len(); i++ {
-		c := condField.Index(i)
-		cType := c.FieldByName("Type").String()
-		cStatus := c.FieldByName("Status").String()
-		conditions = append(conditions, fmt.Sprintf("%s=%s", cType, cStatus))
-	}
-	return fmt.Sprintf("%v", conditions)
 }
 
 func (c *customCtrlClientImpl) StatusUpdate(

--- a/pkg/controller/spiffe-csi-driver/controller.go
+++ b/pkg/controller/spiffe-csi-driver/controller.go
@@ -74,11 +74,6 @@ func (r *SpiffeCsiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// Set Ready to false at the start of reconciliation
-	status.SetInitialReconciliationStatus(ctx, r.ctrlClient, &spiffeCSIDriver, func() *v1alpha1.ConditionalStatus {
-		return &spiffeCSIDriver.Status.ConditionalStatus
-	}, "SpiffeCSIDriver")
-
 	statusMgr := status.NewManager(r.ctrlClient)
 	defer func() {
 		if err := statusMgr.ApplyStatus(ctx, &spiffeCSIDriver, func() *v1alpha1.ConditionalStatus {

--- a/pkg/controller/spire-agent/controller.go
+++ b/pkg/controller/spire-agent/controller.go
@@ -80,11 +80,6 @@ func (r *SpireAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	// Set Ready to false at the start of reconciliation
-	status.SetInitialReconciliationStatus(ctx, r.ctrlClient, &agent, func() *v1alpha1.ConditionalStatus {
-		return &agent.Status.ConditionalStatus
-	}, "SpireAgent")
-
 	statusMgr := status.NewManager(r.ctrlClient)
 	defer func() {
 		if err := statusMgr.ApplyStatus(ctx, &agent, func() *v1alpha1.ConditionalStatus {

--- a/pkg/controller/spire-oidc-discovery-provider/controller.go
+++ b/pkg/controller/spire-oidc-discovery-provider/controller.go
@@ -83,11 +83,6 @@ func (r *SpireOidcDiscoveryProviderReconciler) Reconcile(ctx context.Context, re
 		return ctrl.Result{}, err
 	}
 
-	// Set Ready to false at the start of reconciliation
-	status.SetInitialReconciliationStatus(ctx, r.ctrlClient, &oidcDiscoveryProviderConfig, func() *v1alpha1.ConditionalStatus {
-		return &oidcDiscoveryProviderConfig.Status.ConditionalStatus
-	}, "SpireOIDCDiscoveryProvider")
-
 	statusMgr := status.NewManager(r.ctrlClient)
 	defer func() {
 		if err := statusMgr.ApplyStatus(ctx, &oidcDiscoveryProviderConfig, func() *v1alpha1.ConditionalStatus {

--- a/pkg/controller/spire-server/controller.go
+++ b/pkg/controller/spire-server/controller.go
@@ -84,11 +84,6 @@ func (r *SpireServerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	// Set Ready to false at the start of reconciliation
-	status.SetInitialReconciliationStatus(ctx, r.ctrlClient, &server, func() *v1alpha1.ConditionalStatus {
-		return &server.Status.ConditionalStatus
-	}, "SpireServer")
-
 	statusMgr := status.NewManager(r.ctrlClient)
 	defer func() {
 		if err := statusMgr.ApplyStatus(ctx, &server, func() *v1alpha1.ConditionalStatus {

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -37,19 +37,6 @@ func NewManager(customClient customClient.CustomCtrlClient) *Manager {
 	}
 }
 
-// SetInitialReconciliationStatus sets the Ready condition to false at the start of reconciliation.
-// This ensures that during operator upgrades, the status correctly reflects that reconciliation
-// is in progress. The status is applied immediately before any reconciliation logic runs.
-func SetInitialReconciliationStatus(ctx context.Context, customClient customClient.CustomCtrlClient, obj client.Object, getStatus func() *v1alpha1.ConditionalStatus, resourceName string) {
-	initialStatusMgr := NewManager(customClient)
-	initialStatusMgr.AddCondition(v1alpha1.Ready, v1alpha1.ReasonInProgress,
-		fmt.Sprintf("Reconciling %s", resourceName),
-		metav1.ConditionFalse)
-	if err := initialStatusMgr.ApplyStatus(ctx, obj, getStatus); err != nil {
-		fmt.Printf("cannot apply the initial status %v", err)
-	}
-}
-
 // AddCondition adds or updates a condition
 func (m *Manager) AddCondition(conditionType, reason, message string, status metav1.ConditionStatus) {
 	m.conditions[conditionType] = Condition{

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -37,12 +37,6 @@ func NewManager(customClient customClient.CustomCtrlClient) *Manager {
 	}
 }
 
-// GetCondition returns a condition by type if it exists in the manager
-func (m *Manager) GetCondition(conditionType string) (Condition, bool) {
-	c, ok := m.conditions[conditionType]
-	return c, ok
-}
-
 // AddCondition adds or updates a condition
 func (m *Manager) AddCondition(conditionType, reason, message string, status metav1.ConditionStatus) {
 	m.conditions[conditionType] = Condition{
@@ -136,20 +130,10 @@ func (m *Manager) ApplyStatus(ctx context.Context, obj client.Object, getStatus 
 	}
 
 	// Only update if status has changed
-	statusChanged := !equality.Semantic.DeepEqual(originalStatus, status)
-	fmt.Printf("DIAG ApplyStatus: obj=%s rv=%s statusChanged=%v conditionsInMgr=%d\n",
-		obj.GetName(), obj.GetResourceVersion(), statusChanged, len(m.conditions))
-	if statusChanged {
+	if !equality.Semantic.DeepEqual(originalStatus, status) {
 		if err := m.customClient.StatusUpdateWithRetry(ctx, obj); err != nil {
-			fmt.Printf("DIAG ApplyStatus: StatusUpdateWithRetry FAILED for %s rv=%s err=%v\n",
-				obj.GetName(), obj.GetResourceVersion(), err)
 			return fmt.Errorf("failed to update status: %w", err)
 		}
-		fmt.Printf("DIAG ApplyStatus: StatusUpdateWithRetry SUCCEEDED for %s newRV=%s\n",
-			obj.GetName(), obj.GetResourceVersion())
-	} else {
-		fmt.Printf("DIAG ApplyStatus: SKIPPED write for %s rv=%s (no change detected)\n",
-			obj.GetName(), obj.GetResourceVersion())
 	}
 
 	return nil

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -37,6 +37,12 @@ func NewManager(customClient customClient.CustomCtrlClient) *Manager {
 	}
 }
 
+// GetCondition returns a condition by type if it exists in the manager
+func (m *Manager) GetCondition(conditionType string) (Condition, bool) {
+	c, ok := m.conditions[conditionType]
+	return c, ok
+}
+
 // AddCondition adds or updates a condition
 func (m *Manager) AddCondition(conditionType, reason, message string, status metav1.ConditionStatus) {
 	m.conditions[conditionType] = Condition{
@@ -130,10 +136,20 @@ func (m *Manager) ApplyStatus(ctx context.Context, obj client.Object, getStatus 
 	}
 
 	// Only update if status has changed
-	if !equality.Semantic.DeepEqual(originalStatus, status) {
+	statusChanged := !equality.Semantic.DeepEqual(originalStatus, status)
+	fmt.Printf("DIAG ApplyStatus: obj=%s rv=%s statusChanged=%v conditionsInMgr=%d\n",
+		obj.GetName(), obj.GetResourceVersion(), statusChanged, len(m.conditions))
+	if statusChanged {
 		if err := m.customClient.StatusUpdateWithRetry(ctx, obj); err != nil {
+			fmt.Printf("DIAG ApplyStatus: StatusUpdateWithRetry FAILED for %s rv=%s err=%v\n",
+				obj.GetName(), obj.GetResourceVersion(), err)
 			return fmt.Errorf("failed to update status: %w", err)
 		}
+		fmt.Printf("DIAG ApplyStatus: StatusUpdateWithRetry SUCCEEDED for %s newRV=%s\n",
+			obj.GetName(), obj.GetResourceVersion())
+	} else {
+		fmt.Printf("DIAG ApplyStatus: SKIPPED write for %s rv=%s (no change detected)\n",
+			obj.GetName(), obj.GetResourceVersion())
 	}
 
 	return nil

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -381,28 +381,6 @@ func TestNewManager(t *testing.T) {
 	}
 }
 
-func TestSetInitialReconciliationStatus(t *testing.T) {
-	tests := []struct {
-		name        string
-		updateError error
-	}{
-		{name: "successful update", updateError: nil},
-		{name: "update error handled gracefully", updateError: errors.New("update failed")},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := &fakes.FakeCustomCtrlClient{}
-			fakeClient.StatusUpdateWithRetryReturns(tt.updateError)
-
-			obj := &v1alpha1.SpireServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
-			SetInitialReconciliationStatus(context.Background(), fakeClient, obj, func() *v1alpha1.ConditionalStatus {
-				return &obj.Status.ConditionalStatus
-			}, "SpireServer")
-		})
-	}
-}
-
 func TestApplyStatus(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/controller/zero-trust-workload-identity-manager/controller.go
+++ b/pkg/controller/zero-trust-workload-identity-manager/controller.go
@@ -249,11 +249,6 @@ func (r *ZeroTrustWorkloadIdentityManagerReconciler) Reconcile(ctx context.Conte
 		}
 		return ctrl.Result{}, err
 	}
-	// Set Ready to false at the start of reconciliation
-	status.SetInitialReconciliationStatus(ctx, r.ctrlClient, &config, func() *v1alpha1.ConditionalStatus {
-		return &config.Status.ConditionalStatus
-	}, "ZeroTrustWorkloadIdentityManager")
-
 	statusMgr := status.NewManager(r.ctrlClient)
 
 	defer func() {

--- a/pkg/controller/zero-trust-workload-identity-manager/controller.go
+++ b/pkg/controller/zero-trust-workload-identity-manager/controller.go
@@ -250,30 +250,13 @@ func (r *ZeroTrustWorkloadIdentityManagerReconciler) Reconcile(ctx context.Conte
 		return ctrl.Result{}, err
 	}
 
-	// DIAG: Log the RV and CreateOnlyMode condition from the cache-backed Get
-	cachedRV := config.GetResourceVersion()
-	cachedCreateOnlyMode := "nil"
-	if c := apimeta.FindStatusCondition(config.Status.ConditionalStatus.Conditions, CreateOnlyMode); c != nil {
-		cachedCreateOnlyMode = string(c.Status)
-	}
-	r.log.Info("DIAG: cache read", "rv", cachedRV, "cachedCreateOnlyMode", cachedCreateOnlyMode, "envCreateOnlyMode", utils.IsInCreateOnlyMode(), "conditionCount", len(config.Status.ConditionalStatus.Conditions))
-
 	statusMgr := status.NewManager(r.ctrlClient)
 
 	defer func() {
-		// DIAG: Log what the status manager is about to write
-		createOnlyInMgr := "not-set"
-		if c, ok := statusMgr.GetCondition(CreateOnlyMode); ok {
-			createOnlyInMgr = string(c.Status)
-		}
-		r.log.Info("DIAG: deferred ApplyStatus starting", "rv", config.GetResourceVersion(), "createOnlyModeInStatusMgr", createOnlyInMgr)
-
 		if err := statusMgr.ApplyStatus(ctx, &config, func() *v1alpha1.ConditionalStatus {
 			return &config.Status.ConditionalStatus
 		}); err != nil {
-			r.log.Error(err, "DIAG: deferred ApplyStatus FAILED", "rv", config.GetResourceVersion())
-		} else {
-			r.log.Info("DIAG: deferred ApplyStatus succeeded", "newRV", config.GetResourceVersion())
+			r.log.Error(err, "failed to update status")
 		}
 	}()
 

--- a/pkg/controller/zero-trust-workload-identity-manager/controller.go
+++ b/pkg/controller/zero-trust-workload-identity-manager/controller.go
@@ -249,13 +249,31 @@ func (r *ZeroTrustWorkloadIdentityManagerReconciler) Reconcile(ctx context.Conte
 		}
 		return ctrl.Result{}, err
 	}
+
+	// DIAG: Log the RV and CreateOnlyMode condition from the cache-backed Get
+	cachedRV := config.GetResourceVersion()
+	cachedCreateOnlyMode := "nil"
+	if c := apimeta.FindStatusCondition(config.Status.ConditionalStatus.Conditions, CreateOnlyMode); c != nil {
+		cachedCreateOnlyMode = string(c.Status)
+	}
+	r.log.Info("DIAG: cache read", "rv", cachedRV, "cachedCreateOnlyMode", cachedCreateOnlyMode, "envCreateOnlyMode", utils.IsInCreateOnlyMode(), "conditionCount", len(config.Status.ConditionalStatus.Conditions))
+
 	statusMgr := status.NewManager(r.ctrlClient)
 
 	defer func() {
+		// DIAG: Log what the status manager is about to write
+		createOnlyInMgr := "not-set"
+		if c, ok := statusMgr.GetCondition(CreateOnlyMode); ok {
+			createOnlyInMgr = string(c.Status)
+		}
+		r.log.Info("DIAG: deferred ApplyStatus starting", "rv", config.GetResourceVersion(), "createOnlyModeInStatusMgr", createOnlyInMgr)
+
 		if err := statusMgr.ApplyStatus(ctx, &config, func() *v1alpha1.ConditionalStatus {
 			return &config.Status.ConditionalStatus
 		}); err != nil {
-			r.log.Error(err, "failed to update status")
+			r.log.Error(err, "DIAG: deferred ApplyStatus FAILED", "rv", config.GetResourceVersion())
+		} else {
+			r.log.Info("DIAG: deferred ApplyStatus succeeded", "newRV", config.GetResourceVersion())
 		}
 	}()
 


### PR DESCRIPTION
Remove SetInitialReconciliationStatus which caused a double status write per reconcile. The informer cache returns a stale RV after the first write, causing the deferred ApplyStatus to get rejected with 409 Conflict. Also fixes error wrapping in retry closures to comply with RetryOnConflict contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and consistent error messages when resource or status updates fail (errors are now wrapped with context).

* **Refactor**
  * Controllers no longer set an initial "Ready=false" at reconcile start; status is assembled and applied via a central manager at reconcile end.
  * Removed the standalone initial-reconciliation helper; reconciliations use the manager-based flow.

* **Tests**
  * Tests updated to validate manager-based status application and retry behavior.

* **Chores**
  * Controller manager now enables leader election via configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->