### PR TITLE
SPIRE-557: Update operand version: csi-node-driver-registrar v2.15.0

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2026-06-03T06:34:23Z"
+    createdAt: "2026-06-03T12:11:19Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -713,7 +713,7 @@ spec:
                 - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
                   value: ghcr.io/spiffe/spire-controller-manager:0.6.4
                 - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
-                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
+                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
                 - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
                   value: registry.access.redhat.com/ubi9:latest
                 - name: OPERATOR_LOG_LEVEL
@@ -804,7 +804,7 @@ spec:
     name: spire-oidc-discovery-provider
   - image: ghcr.io/spiffe/spire-controller-manager:0.6.4
     name: spire-controller-manager
-  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
+  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
     name: node-driver-registrar
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -90,7 +90,7 @@ spec:
         - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
           value: ghcr.io/spiffe/spire-controller-manager:0.6.4
         - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
-          value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4
+          value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
         - name: RELATED_IMAGE_SPIFFE_CSI_INIT_CONTAINER
           value: registry.access.redhat.com/ubi9:latest
         - name: OPERATOR_LOG_LEVEL


### PR DESCRIPTION
## Summary
- Bump csi-node-driver-registrar from v2.9.4 to v2.15.0
- Regenerated bundle manifests via `make bundle`

### Compatibility
- CSI spec v1.11.0 matches OCP 4.19-4.21
- Zero k8s API server interaction at runtime (kubelet plugin registration Unix socket only)
- k8s.io/* v0.34.0 dependencies are compile-time only
- Picks up CVE-2025-22872 fix

## Files Changed
- `config/manager/manager.yaml` — updated `RELATED_IMAGE_NODE_DRIVER_REGISTRAR` env var
- `bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml` — regenerated CSV with updated env var and `relatedImages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the node driver registrar image from v2.9.4 to v2.15.0 to bring the controller to a newer driver registrar release.
  * Updated release metadata timestamp in the deployed manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->