### PR TITLE
NO-JIRA: Bump operator version from 1.0.1 to 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.1
+VERSION ?= 1.1.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2026-04-29T11:14:08Z"
+    createdAt: "2026-06-03T06:34:23Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -234,7 +234,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v1.0.1
+  name: zero-trust-workload-identity-manager.v1.1.0
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -701,7 +701,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: zero-trust-workload-identity-manager
                 - name: OPERATOR_VERSION
-                  value: 1.0.1
+                  value: 1.1.0
                 - name: RELATED_IMAGE_SPIRE_SERVER
                   value: ghcr.io/spiffe/spire-server:1.14.7
                 - name: RELATED_IMAGE_SPIRE_AGENT
@@ -808,4 +808,4 @@ spec:
     name: node-driver-registrar
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container
-  version: 1.0.1
+  version: 1.1.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
         - name: OPERATOR_NAME
           value: zero-trust-workload-identity-manager
         - name: OPERATOR_VERSION
-          value: 1.0.1
+          value: 1.1.0
         - name: RELATED_IMAGE_SPIRE_SERVER
           value: ghcr.io/spiffe/spire-server:1.14.7
         - name: RELATED_IMAGE_SPIRE_AGENT

--- a/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v1.0.1
+  name: zero-trust-workload-identity-manager.v1.1.0
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -73,4 +73,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 1.0.1
+  version: 1.1.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ var (
 	SHORTCOMMIT string
 
 	// Operator version (informational)
-	OperatorVersion string = "1.0.1"
+	OperatorVersion string = "1.1.0"
 
 	// Per-component versions (used for app.kubernetes.io/version labels)
 	SpiffeCsiVersion                  string = "0.2.8"


### PR DESCRIPTION
## Summary
- Update operator version from 1.0.1 to 1.1.0 across all source files (Makefile, pkg/version/version.go, config/manager/manager.yaml, CSV bases)
- Regenerate bundle manifests and bindata from updated sources

## Files Changed
| File | Change |
|---|---|
| `Makefile` | `VERSION ?= 1.0.1` -> `1.1.0` |
| `pkg/version/version.go` | `OperatorVersion` -> `1.1.0` |
| `config/manager/manager.yaml` | `OPERATOR_VERSION` env var -> `1.1.0` |
| `config/manifests/bases/...clusterserviceversion.yaml` | CSV name + version -> `1.1.0` |
| `bundle/manifests/...clusterserviceversion.yaml` | Regenerated via `make bundle` |

## Test plan
- [ ] Verify `make bundle` succeeds and bundle validates
- [ ] Verify `make update-bindata` regenerates cleanly
- [ ] Verify operator reports version 1.1.0 at runtime
- [ ] CI passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator version from 1.0.1 to 1.1.0 across build configuration, Kubernetes manifests, and deployment specifications to align with the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->