### PR TITLE
NO-JIRA: Add ignored vendor files to fix hermeto vendoring check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace file
-go.work
-go.work.sum
+# Go workspace file (only at repo root, not inside vendor/)
+/go.work
+/go.work.sum
 
 # env file
 .env

--- a/vendor/github.com/go-openapi/swag/go.work
+++ b/vendor/github.com/go-openapi/swag/go.work
@@ -1,0 +1,20 @@
+use (
+	.
+	./cmdutils
+	./conv
+	./fileutils
+	./jsonname
+	./jsonutils
+	./jsonutils/adapters/easyjson
+	./jsonutils/adapters/testintegration
+	./jsonutils/adapters/testintegration/benchmarks
+	./jsonutils/fixtures_test
+	./loading
+	./mangling
+	./netutils
+	./stringutils
+	./typeutils
+	./yamlutils
+)
+
+go 1.24.0

--- a/vendor/github.com/go-openapi/swag/go.work.sum
+++ b/vendor/github.com/go-openapi/swag/go.work.sum
@@ -1,0 +1,4 @@
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=


### PR DESCRIPTION
## Summary

Konflux builds are failing on `release-1.1` because of missing vendor files that are excluded by `.gitignore` (`go.work` pattern).

The hermeto prefetch-dependencies step runs in strict mode and detects vendor directory drift:

```
[mode:STRICT] vendor directory changed after vendoring:
A	vendor/github.com/go-openapi/swag/go.work
A	vendor/github.com/go-openapi/swag/go.work.sum

PackageRejected: The content of the vendor directory is not consistent with go.mod.
```

## Changes

1. **Update `.gitignore`**: Change `go.work` / `go.work.sum` exclusion to `/go.work` / `/go.work.sum` (leading `/`) so it only applies at the repo root, not inside `vendor/` subdirectories. This prevents future occurrences of this issue.

2. **Add missing vendor files**: Add `vendor/github.com/go-openapi/swag/go.work` and `vendor/github.com/go-openapi/swag/go.work.sum` that are required for hermeto strict vendor consistency checks.

This is the same fix that was applied to `release-1.0.0` in #119, with an additional `.gitignore` improvement to prevent recurrence.

## Cherry-pick targets

- `release-1.1`