### PR TITLE
SPIRE-318: add input validation in operator's CRDs

### DIFF
--- a/api/v1alpha1/spiffe_csi_config_types.go
+++ b/api/v1alpha1/spiffe_csi_config_types.go
@@ -28,8 +28,9 @@ type SpiffeCSIDriverSpec struct {
 	// This directory will be bind-mounted into workload containers by the CSI driver.
 	// The directory is shared between the SPIRE agent and CSI driver via a hostPath volume.
 	// Must be an absolute path without traversal attempts or null bytes.
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Pattern=`^/[a-zA-Z0-9._/\-]*$`
+	// +kubebuilder:validation:Pattern=`^/[a-zA-Z0-9._/\-]+$`
 	// +kubebuilder:default:="/run/spire/agent-sockets"
 	AgentSocketPath string `json:"agentSocketPath,omitempty"`
 

--- a/api/v1alpha1/spire_agent_config_types.go
+++ b/api/v1alpha1/spire_agent_config_types.go
@@ -29,8 +29,9 @@ type SpireAgentSpec struct {
 	// This directory is shared with the SPIFFE CSI driver via hostPath volume.
 	// Must match SpiffeCSIDriver.spec.agentSocketPath for workloads to access the socket.
 	// Must be an absolute path without traversal attempts or null bytes.
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Pattern=`^/[a-zA-Z0-9._/\-]*$`
+	// +kubebuilder:validation:Pattern=`^/[a-zA-Z0-9._/\-]+$`
 	// +kubebuilder:default:="/run/spire/agent-sockets"
 	SocketPath string `json:"socketPath,omitempty"`
 

--- a/api/v1alpha1/spire_server_config_types.go
+++ b/api/v1alpha1/spire_server_config_types.go
@@ -355,8 +355,10 @@ type CASubject struct {
 	Organization string `json:"organization,omitempty"`
 
 	// commonName specifies the common name for the CA.
+	// Must contain only alphanumeric characters, spaces, dots, underscores, or hyphens.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength=255
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9 ._-]*$`
 	CommonName string `json:"commonName,omitempty"`
 }
 

--- a/bundle/manifests/operator.openshift.io_spiffecsidrivers.yaml
+++ b/bundle/manifests/operator.openshift.io_spiffecsidrivers.yaml
@@ -964,7 +964,8 @@ spec:
                   The directory is shared between the SPIRE agent and CSI driver via a hostPath volume.
                   Must be an absolute path without traversal attempts or null bytes.
                 maxLength: 256
-                pattern: ^/[a-zA-Z0-9._/\-]*$
+                minLength: 1
+                pattern: ^/[a-zA-Z0-9._/\-]+$
                 type: string
               labels:
                 additionalProperties:

--- a/bundle/manifests/operator.openshift.io_spireagents.yaml
+++ b/bundle/manifests/operator.openshift.io_spireagents.yaml
@@ -1080,7 +1080,8 @@ spec:
                   Must match SpiffeCSIDriver.spec.agentSocketPath for workloads to access the socket.
                   Must be an absolute path without traversal attempts or null bytes.
                 maxLength: 256
-                pattern: ^/[a-zA-Z0-9._/\-]*$
+                minLength: 1
+                pattern: ^/[a-zA-Z0-9._/\-]+$
                 type: string
               tolerations:
                 description: |-

--- a/bundle/manifests/operator.openshift.io_spireservers.yaml
+++ b/bundle/manifests/operator.openshift.io_spireservers.yaml
@@ -973,8 +973,11 @@ spec:
                   CA.
                 properties:
                   commonName:
-                    description: commonName specifies the common name for the CA.
+                    description: |-
+                      commonName specifies the common name for the CA.
+                      Must contain only alphanumeric characters, spaces, dots, underscores, or hyphens.
                     maxLength: 255
+                    pattern: ^[a-zA-Z0-9 ._-]*$
                     type: string
                   country:
                     description: |-

--- a/config/crd/bases/operator.openshift.io_spiffecsidrivers.yaml
+++ b/config/crd/bases/operator.openshift.io_spiffecsidrivers.yaml
@@ -964,7 +964,8 @@ spec:
                   The directory is shared between the SPIRE agent and CSI driver via a hostPath volume.
                   Must be an absolute path without traversal attempts or null bytes.
                 maxLength: 256
-                pattern: ^/[a-zA-Z0-9._/\-]*$
+                minLength: 1
+                pattern: ^/[a-zA-Z0-9._/\-]+$
                 type: string
               labels:
                 additionalProperties:

--- a/config/crd/bases/operator.openshift.io_spireagents.yaml
+++ b/config/crd/bases/operator.openshift.io_spireagents.yaml
@@ -1080,7 +1080,8 @@ spec:
                   Must match SpiffeCSIDriver.spec.agentSocketPath for workloads to access the socket.
                   Must be an absolute path without traversal attempts or null bytes.
                 maxLength: 256
-                pattern: ^/[a-zA-Z0-9._/\-]*$
+                minLength: 1
+                pattern: ^/[a-zA-Z0-9._/\-]+$
                 type: string
               tolerations:
                 description: |-

--- a/config/crd/bases/operator.openshift.io_spireservers.yaml
+++ b/config/crd/bases/operator.openshift.io_spireservers.yaml
@@ -973,8 +973,11 @@ spec:
                   CA.
                 properties:
                   commonName:
-                    description: commonName specifies the common name for the CA.
+                    description: |-
+                      commonName specifies the common name for the CA.
+                      Must contain only alphanumeric characters, spaces, dots, underscores, or hyphens.
                     maxLength: 255
+                    pattern: ^[a-zA-Z0-9 ._-]*$
                     type: string
                   country:
                     description: |-


### PR DESCRIPTION
Issues Fixed:
- `SpireServer`: Special characters in commonName. Added Pattern=`^[a-zA-Z0-9 ._-]*$` to restrict to safe X.509 CN characters (letters, digits, spaces, dots, underscores, hyphens).
- `SpiffeCSIDriver`: Empty string for agentSocketPath. Added `MinLength=1` and tightened the pattern from * (zero-or-more) to + (one-or-more) on both `SpiffeCSIDriver.spec.agentSocketPath` and `SpireAgent.spec.socketPath` for defense in depth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Tightened `agentSocketPath` validation for `SpiffeCSIDriver` to require a non-empty absolute path and match the allowed character set.
- Tightened `socketPath` validation for `SpireAgent` to require a non-empty absolute path and match the allowed character set.
- Added stricter `caSubject.commonName` validation for `SpireServer`, limiting it to an explicit set of allowed characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->