### PR TITLE
e2e: verify spire-agent runs as root with namespace GID range

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -336,6 +336,58 @@ var _ = Describe("Zero Trust Workload Identity Manager", Ordered, func() {
 			}
 		})
 
+		It("SPIRE Agent process should run as root with supplemental GID within namespace range", func() {
+			By("Getting a ready spire-agent pod")
+			agentPod, err := utils.GetReadySpireAgentPod(testCtx, clientset)
+			Expect(err).NotTo(HaveOccurred(), "should find a ready spire-agent pod")
+			fmt.Fprintf(GinkgoWriter, "using spire-agent pod: %s\n", agentPod.Name)
+
+			By("Executing grep on /proc/self/status in spire-agent container")
+			effectiveUID, gids, err := utils.GetProcStatusFromPod(testCtx, utils.OperatorNamespace,
+				agentPod.Name, utils.SpireAgentContainerName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get proc status from spire-agent pod")
+			fmt.Fprintf(GinkgoWriter, "spire-agent process: effectiveUID=%d, Groups=%v\n", effectiveUID, gids)
+
+			By("Verifying process runs as root (UID 0)")
+			Expect(effectiveUID).To(Equal(0), "spire-agent process should run as root (UID 0)")
+
+			By("Verifying process has root group (GID 0)")
+			hasRootGroup := false
+			for _, g := range gids {
+				if g == 0 {
+					hasRootGroup = true
+					break
+				}
+			}
+			Expect(hasRootGroup).To(BeTrue(), "spire-agent process should have root group (GID 0) in Groups")
+
+			By("Fetching namespace supplemental-groups annotation")
+			operatorNS := &corev1.Namespace{}
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: utils.OperatorNamespace}, operatorNS)).To(Succeed(),
+				"failed to fetch operator namespace %s", utils.OperatorNamespace)
+
+			ann := operatorNS.Annotations["openshift.io/sa.scc.supplemental-groups"]
+			Expect(strings.TrimSpace(ann)).NotTo(BeEmpty(),
+				"namespace %s should have supplemental groups annotation", utils.OperatorNamespace)
+
+			rangeStart, rangeSize, err := utils.ParseSupplementalRange(ann)
+			Expect(err).NotTo(HaveOccurred(), "failed to parse supplemental groups annotation %q", ann)
+
+			By("Verifying process has supplemental GID within namespace range")
+			rangeEnd := rangeStart + rangeSize
+			hasSupplementalGID := false
+			for _, g := range gids {
+				if g >= rangeStart && g < rangeEnd {
+					hasSupplementalGID = true
+					fmt.Fprintf(GinkgoWriter, "found supplemental GID %d within namespace range [%d, %d)\n", g, rangeStart, rangeEnd)
+					break
+				}
+			}
+			Expect(hasSupplementalGID).To(BeTrue(),
+				"spire-agent process should have at least one supplemental GID within namespace range [%d, %d); actual Groups=%v",
+				rangeStart, rangeEnd, gids)
+		})
+
 		It("Prometheus metrics endpoint should be serving", func() {
 			By("Verifying metrics Service exists with correct port configuration")
 			metricsSvc, err := clientset.CoreV1().Services(utils.OperatorNamespace).Get(testCtx,

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -32,6 +32,7 @@ const (
 	SpireServerConfigKey                     = "server.conf"
 	SpireAgentDaemonSetName                  = "spire-agent"
 	SpireAgentPodLabel                       = "app.kubernetes.io/name=spire-agent"
+	SpireAgentContainerName                  = "spire-agent"
 	SpireAgentConfigMapName                  = "spire-agent"
 	SpireAgentConfigKey                      = "agent.conf"
 	SpiffeCSIDriverDaemonSetName             = "spire-spiffe-csi-driver"

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/rand"
@@ -25,8 +26,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -217,6 +220,103 @@ func ExecInPod(ctx context.Context, namespace, podName, containerName string, co
 		return stdoutBuf.String(), stderrBuf.String(), fmt.Errorf("exec %s %v: %w", cli, args, err)
 	}
 	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
+// ParseProcStatusUIDGIDs parses /proc/self/status content and returns effective UID and group IDs.
+// It expects lines like:
+// Uid:    0   0   0   0
+// Gid:    0   0   0   0
+// Groups: 0
+func ParseProcStatusUIDGIDs(content string) (int, []int, error) {
+	var (
+		effectiveUID int
+		gids         []int
+		uidSeen      bool
+		groupsSeen   bool
+	)
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "Uid:"):
+			fields := strings.Fields(line)
+			// fields: ["Uid:", real, effective, saved, fs]
+			if len(fields) < 3 {
+				return 0, nil, fmt.Errorf("Uid line malformed: %q", line)
+			}
+			val, err := strconv.Atoi(fields[2]) // effective UID
+			if err != nil {
+				return 0, nil, fmt.Errorf("failed to parse effective UID from %q: %w", line, err)
+			}
+			effectiveUID = val
+			uidSeen = true
+		case strings.HasPrefix(line, "Groups:"):
+			fields := strings.Fields(line)
+			// fields: ["Groups:", gid1, gid2, ...]
+			if len(fields) < 2 {
+				return 0, nil, fmt.Errorf("Groups line malformed: %q", line)
+			}
+			for _, g := range fields[1:] {
+				val, err := strconv.Atoi(g)
+				if err != nil {
+					return 0, nil, fmt.Errorf("failed to parse group from %q: %w", line, err)
+				}
+				gids = append(gids, val)
+			}
+			groupsSeen = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, nil, fmt.Errorf("failed to scan proc status: %w", err)
+	}
+	if !uidSeen {
+		return 0, nil, fmt.Errorf("Uid line not found in proc status")
+	}
+	if !groupsSeen {
+		return 0, nil, fmt.Errorf("Groups line not found in proc status")
+	}
+	if len(gids) == 0 {
+		return 0, nil, fmt.Errorf("no groups parsed from proc status")
+	}
+	return effectiveUID, gids, nil
+}
+
+// ParseSupplementalRange parses the namespace supplemental groups annotation value (format: "start/size")
+// and returns start and size as integers.
+func ParseSupplementalRange(ann string) (int, int, error) {
+	ann = strings.TrimSpace(ann)
+	if ann == "" {
+		return 0, 0, fmt.Errorf("supplemental groups annotation is empty")
+	}
+
+	parts := strings.SplitN(ann, "/", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid supplemental groups annotation format: %q", ann)
+	}
+
+	start, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse start from %q: %w", ann, err)
+	}
+	if start < 0 {
+		return 0, 0, fmt.Errorf("supplemental groups annotation start must be non-negative: %q", ann)
+	}
+
+	size, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse size from %q: %w", ann, err)
+	}
+	if size <= 0 {
+		return 0, 0, fmt.Errorf("supplemental groups annotation size must be positive: %q", ann)
+	}
+
+	// Check for integer overflow when computing range end (start + size)
+	if start > math.MaxInt-size {
+		return 0, 0, fmt.Errorf("supplemental groups range end overflows int: start=%d, size=%d", start, size)
+	}
+
+	return start, size, nil
 }
 
 // ReadSVIDPEM reads /certs/svid.pem from the given pod container.
@@ -899,6 +999,38 @@ func WaitForUpgradeableStatus(ctx context.Context, k8sClient client.Client, name
 		return true
 	}).WithTimeout(timeout).WithPolling(ShortInterval).Should(BeTrue(),
 		"Upgradeable condition should have status '%v' within %v", expectedStatus, timeout)
+}
+
+// GetReadySpireAgentPod returns the first ready spire-agent pod in the operator namespace.
+// Returns nil if no ready pod is found.
+func GetReadySpireAgentPod(ctx context.Context, clientset kubernetes.Interface) (*corev1.Pod, error) {
+	pods, err := clientset.CoreV1().Pods(OperatorNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: SpireAgentPodLabel,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list spire-agent pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no spire-agent pods found")
+	}
+
+	for i := range pods.Items {
+		if IsPodReady(&pods.Items[i]) {
+			return &pods.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no ready spire-agent pod found (pods=%d)", len(pods.Items))
+}
+
+// GetProcStatusFromPod executes grep on /proc/self/status in a pod and returns UID and Groups.
+// Returns effective UID and list of group IDs.
+func GetProcStatusFromPod(ctx context.Context, namespace, podName, containerName string) (int, []int, error) {
+	stdout, stderr, err := ExecInPod(ctx, namespace, podName, containerName,
+		[]string{"sh", "-c", "grep -E '^(Uid|Gid|Groups)' /proc/self/status"})
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read /proc/self/status (stderr: %s): %w", strings.TrimSpace(stderr), err)
+	}
+	return ParseProcStatusUIDGIDs(stdout)
 }
 
 // SpiffeHelperConfig holds configuration for the spiffe-helper sidecar (helper.conf format).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test validating the SPIRE Agent runs with effective UID `0` and that at least one supplemental GID falls within the OpenShift SCC `supplemental-groups` range for the operator namespace.
* **Tests**
  * Enhanced end-to-end test utilities with parsing helpers to extract UID/GIDs from `/proc/*/status` content and parse `start/size` supplemental group annotation values.
* **Chores**
  * Added a named constant for the SPIRE Agent container name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->