### PR TITLE
OAPE-694: Improve coverage collection reliability and add .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto
+
+ignore:
+  - "vendor/**"
+  - "test/**"
+  - "hack/**"
+  - "docs/**"
+  - "bindata/**"
+  - "config/**"
+  - "bundle/**"
+  - "release/**"
+  - "tools/**"
+  - "**/*_test.go"
+  - "**/zz_generated*.go"
+  - "pkg/operator/assets/bindata.go"
+  - "**/doc.go"

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -76,11 +76,28 @@ collect() {
     fi
     echo "Operator pod: ${pod}"
 
-    echo "Sending SIGTERM to operator process to flush coverage data..."
-    oc exec -n "${NAMESPACE}" "${pod}" -c manager -- /bin/sh -c 'kill -TERM 1' || true
+    local restart_count
+    restart_count=$(oc get pod "${pod}" -n "${NAMESPACE}" \
+        -o jsonpath='{.status.containerStatuses[0].restartCount}')
+    if [[ -z "${restart_count}" ]]; then
+        echo "Error: could not determine restart count for operator container" >&2
+        exit 1
+    fi
 
-    echo "Waiting for container to restart..."
-    oc wait pod/"${pod}" --for=condition=Ready=False -n "${NAMESPACE}" --timeout=30s 2>/dev/null || true
+    echo "Sending SIGTERM to operator process to flush coverage data..."
+    oc exec -n "${NAMESPACE}" "${pod}" -c manager -- /bin/sh -c 'kill -TERM 1'
+
+    echo "Waiting for container restart count to increment..."
+    local expected_count=$((restart_count + 1))
+    if oc wait "pod/${pod}" -n "${NAMESPACE}" \
+        --for="jsonpath={.status.containerStatuses[0].restartCount}=${expected_count}" \
+        --timeout=120s; then
+        echo "Container restarted (count: ${restart_count} -> ${expected_count})"
+    else
+        echo "Error: timed out waiting for container restart" >&2
+        exit 1
+    fi
+
     oc wait pod/"${pod}" --for=condition=Ready -n "${NAMESPACE}" --timeout=120s
 
     mkdir -p "${coverage_dir}"
@@ -100,6 +117,8 @@ collect() {
         echo "============================="
         echo ""
         echo "Coverage profile: ${coverage_profile} ($(wc -l < "${coverage_profile}") lines)"
+
+        rm -rf "${coverage_dir}"
 
         if [[ -n "${CODECOV_TOKEN:-}" ]]; then
             echo "Uploading to Codecov..."


### PR DESCRIPTION
Improves the reliability of E2E coverage collection:
- Replace sleep-based waits with restart count polling for deterministic container restart detection after SIGTERM
- Remove || true from oc exec kill to fail fast on SIGTERM delivery failure
- Clean up raw coverage files after conversion to avoid Prow "Too many files" warning
- Add .codecov.yml to exclude generated files and vendor from coverage reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage collection by recording a container restart signal before terminating to ensure coverage is captured reliably.
  - Added cleanup to remove temporary coverage files after coverage profiles and summaries are generated.

- **Chores**
  - Updated coverage reporting configuration to enable project/patch status checks with automatic targeting.
  - Refined coverage exclusions to skip non-source areas (e.g., vendor/tests/docs/tools), generated/binary patterns, and specific asset/Doc files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->