### PR TITLE
SPIRE-617, OCPBUGS-90556: fix gcInterval to 10s to prevent spire-controller-manager High CPU usage

### DIFF
--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -42,6 +43,12 @@ const (
 	vaultTokenFileName     = "vault"
 	upstreamCAMountPath    = "/run/spire/upstream-ca"
 	upstreamCACertFileName = "ca.crt"
+
+	// defaultControllerManagerGCInterval is the documented spire-controller-manager
+	// default. GCInterval is a non-pointer time.Duration without omitempty, so
+	// leaving it unset serializes as gcInterval: 0
+	// See https://github.com/spiffe/spire-controller-manager/issues/698
+	defaultControllerManagerGCInterval = 10 * time.Second
 )
 
 type ControllerManagerConfigYAML struct {
@@ -629,6 +636,7 @@ func generateControllerManagerConfig(config *v1alpha1.SpireServerSpec, ztwim *v1
 				"local-path-storage",
 				"openshift-*",
 			},
+			GCInterval: defaultControllerManagerGCInterval,
 		},
 	}, nil
 }

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -540,6 +541,7 @@ func TestGenerateSpireControllerManagerConfigYaml(t *testing.T) {
 				"entryIDPrefix: test-cluster":          "",
 				"spireServerSocketPath":                "/tmp/spire-server/private/api.sock",
 				"apiVersion: spire.spiffe.io/v1alpha1": "",
+				fmt.Sprintf("gcInterval: %d", int64(defaultControllerManagerGCInterval)): "",
 			},
 		},
 		{


### PR DESCRIPTION
Unset gcInterval serializes as 0, causing continuous GC loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Controller-manager configuration now includes a default 10-second garbage-collection interval.
* **Bug Fixes**
  * Ensures garbage collection runs at a predictable interval in generated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->