### PR TITLE
Fix high CPU usage in SPIRE server pod (gcInterval)

### DIFF
--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -498,6 +499,7 @@ func generateControllerManagerConfig(config *v1alpha1.SpireServerSpec, ztwim *v1
 				Health: spiffev1alpha.ControllerHealth{
 					HealthProbeBindAddress: "0.0.0.0:8083",
 				},
+				GCInterval:       10 * time.Second,
 				EntryIDPrefix:    ztwim.Spec.ClusterName,
 				WatchClassless:   false,
 				ClassName:        "zero-trust-workload-identity-manager-spire",

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -540,6 +540,7 @@ func TestGenerateSpireControllerManagerConfigYaml(t *testing.T) {
 				"entryIDPrefix: test-cluster":          "",
 				"spireServerSocketPath":                "/tmp/spire-server/private/api.sock",
 				"apiVersion: spire.spiffe.io/v1alpha1": "",
+				"gcInterval: 10s":                      "",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
Fixes high CPU usage (~2300m at idle) in SPIRE server pod by setting the `gcInterval` parameter to 10 seconds instead of allowing it to default to 0.

## Problem
The SPIRE controller-manager's garbage collection interval (`gcInterval`) was unintentionally set to 0 seconds (Go zero value for `time.Duration`), causing continuous garbage collection and excessive CPU consumption.

**Before**: gcInterval: 0 → CPU: ~2300m at idle  
**After**: gcInterval: 10s → Expected CPU: <200m at idle

## Root Cause
In `pkg/controller/spire-server/configmap.go`, the `generateControllerManagerConfig()` function creates a `ControllerManagerConfigurationSpec` struct but does not set the `GCInterval` field. Since Go's zero value for `time.Duration` is `0`, the field defaults to 0 seconds, causing continuous garbage collection.

## Changes
- **pkg/controller/spire-server/configmap.go**: 
  - Add `GCInterval: 10 * time.Second` to `ControllerManagerConfigurationSpec` (line 502)
  - Add `"time"` import
- **pkg/controller/spire-server/configmaps_test.go**: 
  - Add test assertion to verify `gcInterval: 10s` appears in generated YAML

## Testing
- Updated `TestGenerateSpireControllerManagerConfigYaml` to verify the gcInterval field is present in generated YAML
- CI will validate build and test execution
- Expected result: CPU usage drops from ~2300m to <200m at idle after deployment

## Files Changed
```
pkg/controller/spire-server/configmap.go       | 2 ++
pkg/controller/spire-server/configmaps_test.go | 1 +
2 files changed, 3 insertions(+)
```

## Related
Fixes: [SPIRE-617](https://redhat.atlassian.net/browse/SPIRE-617)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 10-second garbage collection interval to the generated SPIRE controller manager configuration.
  * Ensures the controller manager periodically performs garbage collection as configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->