### PR TITLE
ART: Add package.yaml, fix conforma bundle violations

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,2 +1,9 @@
 ---
 updates: []
+external-images:
+- name: ubi9
+  search: "registry.access.redhat.com/ubi9:latest"
+  replace: "registry.access.redhat.com/ubi9:latest"
+- name: csi-node-driver-registrar
+  search: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0"
+  replace: "registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9:latest"

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -355,6 +355,15 @@ spec:
           - get
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations

--- a/bundle/zero-trust-workload-identity-manager.package.yaml
+++ b/bundle/zero-trust-workload-identity-manager.package.yaml
@@ -1,0 +1,6 @@
+---
+packageName: zero-trust-workload-identity-manager
+channels:
+- name: stable
+  currentCSV: zero-trust-workload-identity-manager.v1.1.0
+defaultChannel: stable


### PR DESCRIPTION
## Summary
- Add `bundle/zero-trust-workload-identity-manager.package.yaml` for ART OLM bundle generation
- Add `external-images` config to `bundle/art.yaml` to pin non-ART-built images in the OLM bundle CSV:
  - `registry.access.redhat.com/ubi9:latest` → pinned to digest (fixes `olm.unpinned_references`)
  - `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0` → swapped to `registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9:latest` and pinned (fixes `olm.allowed_registries` + `olm.unpinned_references`)
- Add `networking.k8s.io/networkpolicies` RBAC (create, delete, patch, update) to CSV clusterPermissions (fixes `olm.required_network_policy_rbac_for_operands`)

## Test plan
- [x] Verified `external-images` fix resolves `olm.allowed_registries` and `olm.unpinned_references` violations in verify-conforma
- [x] Verified NetworkPolicy RBAC fix resolves `olm.required_network_policy_rbac_for_operands` violation
- [x] Full release pipeline pass with all images
