### PR TITLE
Update bundle package.yaml channel to alpha

### DIFF
--- a/bundle/zero-trust-workload-identity-manager.package.yaml
+++ b/bundle/zero-trust-workload-identity-manager.package.yaml
@@ -1,6 +1,6 @@
 ---
 packageName: zero-trust-workload-identity-manager
 channels:
-- name: stable
+- name: alpha
   currentCSV: zero-trust-workload-identity-manager.v1.1.0
-defaultChannel: stable
+defaultChannel: alpha


### PR DESCRIPTION
## Summary
- Change channel from `stable` to `alpha` to match upstream production bundle annotations

## Context
Production bundle annotations use `alpha` as the channel name. Our `package.yaml` had `stable` which caused a mismatch in the rendered bundle branch annotations.

## Test plan
- [ ] Verify bundle build produces correct `annotations.yaml` with `channels.v1: alpha`
