### PR TITLE
Update bundle package.yaml channel to stable-v1

### DIFF
--- a/bundle/zero-trust-workload-identity-manager.package.yaml
+++ b/bundle/zero-trust-workload-identity-manager.package.yaml
@@ -1,6 +1,6 @@
 ---
 packageName: zero-trust-workload-identity-manager
 channels:
-- name: alpha
+- name: stable-v1
   currentCSV: zero-trust-workload-identity-manager.v1.1.0
-defaultChannel: alpha
+defaultChannel: stable-v1


### PR DESCRIPTION
## Summary
- Change channel from `alpha` to `stable-v1` per OAPE team confirmation

## Context
OAPE team confirmed the default channel for ZT should be `stable-v1`, consistent with CM and ESO.

## Test plan
- [ ] Verify bundle build produces correct `annotations.yaml` with `channels.v1: stable-v1`
