### PR TITLE
SPIRE-617: name gcInterval as the documented controller-manager default

### DIFF
--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -43,6 +43,13 @@ const (
 	vaultTokenFileName     = "vault"
 	upstreamCAMountPath    = "/run/spire/upstream-ca"
 	upstreamCACertFileName = "ca.crt"
+
+	// defaultControllerManagerGCInterval is the documented spire-controller-manager
+	// default. GCInterval is a non-pointer time.Duration without omitempty, so
+	// leaving it unset serializes as gcInterval: 0. The binary treats 0 as
+	// "run GC with no pause", which causes a tight loop and ~100% CPU.
+	// See https://github.com/spiffe/spire-controller-manager/issues/698
+	defaultControllerManagerGCInterval = 10 * time.Second
 )
 
 type ControllerManagerConfigYAML struct {
@@ -630,7 +637,7 @@ func generateControllerManagerConfig(config *v1alpha1.SpireServerSpec, ztwim *v1
 				"local-path-storage",
 				"openshift-*",
 			},
-			GCInterval: 10 * time.Second,
+			GCInterval: defaultControllerManagerGCInterval,
 		},
 	}, nil
 }

--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -629,6 +630,7 @@ func generateControllerManagerConfig(config *v1alpha1.SpireServerSpec, ztwim *v1
 				"local-path-storage",
 				"openshift-*",
 			},
+			GCInterval: 10 * time.Second,
 		},
 	}, nil
 }

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -540,7 +541,7 @@ func TestGenerateSpireControllerManagerConfigYaml(t *testing.T) {
 				"entryIDPrefix: test-cluster":          "",
 				"spireServerSocketPath":                "/tmp/spire-server/private/api.sock",
 				"apiVersion: spire.spiffe.io/v1alpha1": "",
-				"gcInterval: 10000000000":              "",
+				fmt.Sprintf("gcInterval: %d", int64(defaultControllerManagerGCInterval)): "",
 			},
 		},
 		{

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -540,6 +540,7 @@ func TestGenerateSpireControllerManagerConfigYaml(t *testing.T) {
 				"entryIDPrefix: test-cluster":          "",
 				"spireServerSocketPath":                "/tmp/spire-server/private/api.sock",
 				"apiVersion: spire.spiffe.io/v1alpha1": "",
+				"gcInterval: 10000000000":              "",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Follow-up to #149. **Depends on #149** — merge that first; this PR only adds a named constant and comment on top of the `gcInterval=10s` CPU fix.
- Replaces the magic `10 * time.Second` with `defaultControllerManagerGCInterval` and documents why a zero value must not be serialized (tight GC loop / ~100% CPU; see [spire-controller-manager#698](https://github.com/spiffe/spire-controller-manager/issues/698)).
- Test assertion derives the YAML nanosecond value from that constant: `fmt.Sprintf("gcInterval: %d", int64(defaultControllerManagerGCInterval))`.

Until #149 merges, the commit list vs `main` will also include the original CPU fix.

## Test plan
- [x] `go test ./pkg/controller/spire-server/ -run TestGenerateSpireControllerManagerConfigYaml`
- [ ] Confirm generated ConfigMap still contains `gcInterval: 10000000000` (10s in nanoseconds)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Set a default 10-second garbage collection interval for the SPIRE controller manager.
  * Ensured generated controller-manager configuration explicitly includes this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->