### PR TITLE
SPIRE-344: Validate resource ownership before updating

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -204,10 +204,20 @@ func (c *customCtrlClientImpl) Exists(ctx context.Context, key client.ObjectKey,
 	return true, nil
 }
 
-// CreateOrUpdateObject tries to create the object, updates if already exists
+// CreateOrUpdateObject tries to create the object, updates if already exists.
+// Before updating, it verifies the existing resource is managed by this operator
+// to prevent overwriting resources owned by other applications.
 func (c *customCtrlClientImpl) CreateOrUpdateObject(ctx context.Context, obj client.Object) error {
 	err := c.Create(ctx, obj)
 	if err != nil && errors.IsAlreadyExists(err) {
+		existing := obj.DeepCopyObject().(client.Object)
+		key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+		if getErr := c.Client.Get(ctx, key, existing); getErr != nil {
+			return fmt.Errorf("failed to get existing resource %q for ownership check: %w", key, getErr)
+		}
+		if !utils.IsResourceManagedByOperator(existing) {
+			return utils.NewOwnershipConflictError(obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+		}
 		return c.Update(ctx, obj)
 	}
 	return err

--- a/pkg/controller/spiffe-csi-driver/csi_driver.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver.go
@@ -60,6 +60,16 @@ func (r *SpiffeCsiReconciler) reconcileCSIDriver(ctx context.Context, driver *v1
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("CSIDriver", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(CSIDriverAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("CSIDriver exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spiffe-csi-driver/csi_driver_test.go
+++ b/pkg/controller/spiffe-csi-driver/csi_driver_test.go
@@ -177,7 +177,13 @@ func TestReconcileCSIDriver(t *testing.T) {
 			},
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
 				existingCSI := &storagev1.CSIDriver{
-					ObjectMeta: metav1.ObjectMeta{Name: "csi.spiffe.io", ResourceVersion: "123"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "csi.spiffe.io",
+						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
+					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if csi, ok := obj.(*storagev1.CSIDriver); ok {
@@ -204,7 +210,10 @@ func TestReconcileCSIDriver(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "csi.spiffe.io",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -233,7 +242,10 @@ func TestReconcileCSIDriver(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "csi.spiffe.io",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spiffe-csi-driver/daemonset.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset.go
@@ -42,19 +42,29 @@ func (r *SpiffeCsiReconciler) reconcileDaemonSet(ctx context.Context, driver *v1
 			return fmt.Errorf("failed to create DaemonSet: %w", err)
 		}
 		r.log.Info("Created spiffe csi DaemonSet")
-	} else if err == nil && needsUpdate(existingSpiffeCsiDaemonSet, *spiffeCsiDaemonset) {
-		if createOnlyMode {
-			r.log.Info("Skipping DaemonSet update due to create-only mode")
-		} else {
-			spiffeCsiDaemonset.ResourceVersion = existingSpiffeCsiDaemonSet.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spiffeCsiDaemonset); err != nil {
-				r.log.Error(err, "failed to update spiffe csi daemon set")
-				statusMgr.AddCondition(DaemonSetAvailable, "SpiffeCSIDaemonSetUpdateFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return fmt.Errorf("failed to update DaemonSet: %w", err)
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSpiffeCsiDaemonSet) {
+			ownerErr := utils.NewOwnershipConflictError("DaemonSet", spiffeCsiDaemonset.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", spiffeCsiDaemonset.Name)
+			statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
+		}
+		if needsUpdate(existingSpiffeCsiDaemonSet, *spiffeCsiDaemonset) {
+			if createOnlyMode {
+				r.log.Info("Skipping DaemonSet update due to create-only mode")
+			} else {
+				spiffeCsiDaemonset.ResourceVersion = existingSpiffeCsiDaemonSet.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spiffeCsiDaemonset); err != nil {
+					r.log.Error(err, "failed to update spiffe csi daemon set")
+					statusMgr.AddCondition(DaemonSetAvailable, "SpiffeCSIDaemonSetUpdateFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return fmt.Errorf("failed to update DaemonSet: %w", err)
+				}
+				r.log.Info("Updated spiffe csi DaemonSet")
 			}
-			r.log.Info("Updated spiffe csi DaemonSet")
 		}
 	} else if err != nil {
 		r.log.Error(err, "Failed to get SpiffeCsiDaemon set")

--- a/pkg/controller/spiffe-csi-driver/daemonset_test.go
+++ b/pkg/controller/spiffe-csi-driver/daemonset_test.go
@@ -615,7 +615,10 @@ func TestReconcileDaemonSet(t *testing.T) {
 						Name:            "spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fakeClient.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spiffe-csi-driver/scc.go
+++ b/pkg/controller/spiffe-csi-driver/scc.go
@@ -102,6 +102,16 @@ func (r *SpiffeCsiReconciler) reconcileSCC(ctx context.Context, driver *v1alpha1
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("SecurityContextConstraints", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Preserve fields set by OpenShift from existing resource BEFORE comparison
 	desired.ResourceVersion = existing.ResourceVersion
 	desired.Priority = existing.Priority

--- a/pkg/controller/spiffe-csi-driver/scc_test.go
+++ b/pkg/controller/spiffe-csi-driver/scc_test.go
@@ -601,7 +601,10 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-spiffe-csi-driver",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -629,7 +632,10 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-spiffe-csi-driver",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spiffe-csi-driver/service_account.go
+++ b/pkg/controller/spiffe-csi-driver/service_account.go
@@ -60,6 +60,16 @@ func (r *SpiffeCsiReconciler) reconcileServiceAccount(ctx context.Context, drive
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ServiceAccount", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spiffe-csi-driver/service_account_test.go
+++ b/pkg/controller/spiffe-csi-driver/service_account_test.go
@@ -118,6 +118,9 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -145,7 +148,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -174,7 +180,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-csi-driver",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-agent/configmap.go
+++ b/pkg/controller/spire-agent/configmap.go
@@ -49,20 +49,30 @@ func (r *SpireAgentReconciler) reconcileConfigMap(ctx context.Context, agent *v1
 			return "", fmt.Errorf("failed to create ConfigMap: %w", err)
 		}
 		r.log.Info("Created spire agent ConfigMap")
-	} else if err == nil && (existingSpireAgentCM.Data["agent.conf"] != spireAgentConfigMap.Data["agent.conf"] ||
-		!equality.Semantic.DeepEqual(existingSpireAgentCM.Labels, spireAgentConfigMap.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping ConfigMap update due to create-only mode")
-		} else {
-			spireAgentConfigMap.ResourceVersion = existingSpireAgentCM.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireAgentConfigMap); err != nil {
-				r.log.Error(err, "failed to update spire-agent config map")
-				statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSpireAgentCM) {
+			ownerErr := utils.NewOwnershipConflictError("ConfigMap", spireAgentConfigMap.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", spireAgentConfigMap.Name)
+			statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return "", ownerErr
+		}
+		if existingSpireAgentCM.Data["agent.conf"] != spireAgentConfigMap.Data["agent.conf"] ||
+			!equality.Semantic.DeepEqual(existingSpireAgentCM.Labels, spireAgentConfigMap.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping ConfigMap update due to create-only mode")
+			} else {
+				spireAgentConfigMap.ResourceVersion = existingSpireAgentCM.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireAgentConfigMap); err != nil {
+					r.log.Error(err, "failed to update spire-agent config map")
+					statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+				}
+				r.log.Info("Updated ConfigMap with new config")
 			}
-			r.log.Info("Updated ConfigMap with new config")
 		}
 	} else if err != nil {
 		statusMgr.AddCondition(ConfigMapAvailable, "SpireAgentConfigMapGenerationFailed",

--- a/pkg/controller/spire-agent/controller_test.go
+++ b/pkg/controller/spire-agent/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/client/fakes"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/status"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1254,6 +1255,9 @@ func TestReconcile_FullFlow_AllScenarios(t *testing.T) {
 					if tt.configMapExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						}
 						if tt.configMapDiff {
 							v.Data = map[string]string{"agent.conf": "old-config"}
 						}
@@ -1264,6 +1268,9 @@ func TestReconcile_FullFlow_AllScenarios(t *testing.T) {
 					if tt.daemonSetExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						}
 						return nil
 					}
 					return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
@@ -1378,6 +1385,9 @@ func TestReconcileConfigMap_AllScenarios(t *testing.T) {
 					if tt.cmExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						}
 						if tt.cmDiff {
 							v.Data = map[string]string{"agent.conf": "old-config"}
 						}
@@ -1494,6 +1504,9 @@ func TestReconcileDaemonSet_AllScenarios(t *testing.T) {
 					if tt.dsExists {
 						v.Name = key.Name
 						v.Namespace = key.Namespace
+						v.Labels = map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						}
 						if !tt.dsDiff {
 							// Set same hash to simulate no change needed
 							v.Spec.Template.Annotations = map[string]string{

--- a/pkg/controller/spire-agent/daemonset.go
+++ b/pkg/controller/spire-agent/daemonset.go
@@ -41,19 +41,29 @@ func (r *SpireAgentReconciler) reconcileDaemonSet(ctx context.Context, agent *v1
 			return fmt.Errorf("failed to create DaemonSet: %w", err)
 		}
 		r.log.Info("Created spire agent DaemonSet")
-	} else if err == nil && needsUpdate(existingSpireAgentDaemonSet, *spireAgentDaemonset) {
-		if createOnlyMode {
-			r.log.Info("Skipping DaemonSet update due to create-only mode")
-		} else {
-			spireAgentDaemonset.ResourceVersion = existingSpireAgentDaemonSet.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireAgentDaemonset); err != nil {
-				r.log.Error(err, "failed to update spire agent DaemonSet")
-				statusMgr.AddCondition(DaemonSetAvailable, "SpireAgentDaemonSetUpdateFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return fmt.Errorf("failed to update DaemonSet: %w", err)
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSpireAgentDaemonSet) {
+			ownerErr := utils.NewOwnershipConflictError("DaemonSet", spireAgentDaemonset.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", spireAgentDaemonset.Name)
+			statusMgr.AddCondition(DaemonSetAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
+		}
+		if needsUpdate(existingSpireAgentDaemonSet, *spireAgentDaemonset) {
+			if createOnlyMode {
+				r.log.Info("Skipping DaemonSet update due to create-only mode")
+			} else {
+				spireAgentDaemonset.ResourceVersion = existingSpireAgentDaemonSet.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireAgentDaemonset); err != nil {
+					r.log.Error(err, "failed to update spire agent DaemonSet")
+					statusMgr.AddCondition(DaemonSetAvailable, "SpireAgentDaemonSetUpdateFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return fmt.Errorf("failed to update DaemonSet: %w", err)
+				}
+				r.log.Info("Updated spire agent DaemonSet")
 			}
-			r.log.Info("Updated spire agent DaemonSet")
 		}
 	} else if err != nil {
 		r.log.Error(err, "failed to get spire-agent daemonset")

--- a/pkg/controller/spire-agent/rbac.go
+++ b/pkg/controller/spire-agent/rbac.go
@@ -77,6 +77,16 @@ func (r *SpireAgentReconciler) reconcileClusterRole(ctx context.Context, agent *
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ClusterRole", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRole exists, skipping update due to create-only mode", "name", desired.Name)
@@ -140,6 +150,16 @@ func (r *SpireAgentReconciler) reconcileClusterRoleBinding(ctx context.Context, 
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ClusterRoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-agent/rbac_test.go
+++ b/pkg/controller/spire-agent/rbac_test.go
@@ -275,6 +275,9 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -303,7 +306,10 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -332,7 +338,10 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -450,6 +459,9 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -478,7 +490,10 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -507,7 +522,10 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-agent/scc.go
+++ b/pkg/controller/spire-agent/scc.go
@@ -104,6 +104,16 @@ func (r *SpireAgentReconciler) reconcileSCC(ctx context.Context, agent *v1alpha1
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("SecurityContextConstraints", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(SecurityContextConstraintsAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Preserve fields set by OpenShift from existing resource BEFORE comparison
 	desired.ResourceVersion = existing.ResourceVersion
 	desired.Priority = existing.Priority

--- a/pkg/controller/spire-agent/scc_test.go
+++ b/pkg/controller/spire-agent/scc_test.go
@@ -204,7 +204,10 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -232,7 +235,10 @@ func TestReconcileSCC(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-agent",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -317,7 +323,10 @@ func TestReconcileSCC_PreservesExistingFields(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "spire-agent",
 			ResourceVersion: "123",
-			Labels:          map[string]string{"old-label": "old-value"},
+			Labels: map[string]string{
+				"old-label":                "old-value",
+				utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+			},
 		},
 		Priority:           func() *int32 { p := int32(10); return &p }(),
 		UserNamespaceLevel: "pod",

--- a/pkg/controller/spire-agent/service.go
+++ b/pkg/controller/spire-agent/service.go
@@ -69,6 +69,16 @@ func (r *SpireAgentReconciler) reconcileAgentService(ctx context.Context, agent 
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Service", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Service exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-agent/service_account.go
+++ b/pkg/controller/spire-agent/service_account.go
@@ -60,6 +60,16 @@ func (r *SpireAgentReconciler) reconcileServiceAccount(ctx context.Context, agen
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ServiceAccount", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-agent/service_account_test.go
+++ b/pkg/controller/spire-agent/service_account_test.go
@@ -164,6 +164,9 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -207,7 +210,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -236,7 +242,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-agent/service_test.go
+++ b/pkg/controller/spire-agent/service_test.go
@@ -172,6 +172,9 @@ func TestReconcileAgentService(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -199,7 +202,10 @@ func TestReconcileAgentService(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -229,7 +235,10 @@ func TestReconcileAgentService(t *testing.T) {
 						Name:            "spire-agent",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}

--- a/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
+++ b/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid.go
@@ -51,6 +51,16 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 		}
 		r.log.Info("Created OIDC ClusterSPIFFEID", "name", desiredOIDC.Name)
 	} else {
+		// Verify resource is managed by this operator before updating
+		if !utils.IsResourceManagedByOperator(existingOIDC) {
+			ownerErr := utils.NewOwnershipConflictError("ClusterSPIFFEID", desiredOIDC.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desiredOIDC.Name)
+			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
+		}
+
 		// Resource exists, check if we need to update
 		if utils.ResourceNeedsUpdate(existingOIDC, desiredOIDC) {
 			if createOnlyMode {
@@ -107,6 +117,16 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileClusterSpiffeIDs(ctx con
 		}
 		r.log.Info("Created Default ClusterSPIFFEID", "name", desiredDefault.Name)
 	} else {
+		// Verify resource is managed by this operator before updating
+		if !utils.IsResourceManagedByOperator(existingDefault) {
+			ownerErr := utils.NewOwnershipConflictError("ClusterSPIFFEID", desiredDefault.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desiredDefault.Name)
+			statusMgr.AddCondition(ClusterSPIFFEIDAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
+		}
+
 		// Resource exists, check if we need to update
 		if utils.ResourceNeedsUpdate(existingDefault, desiredDefault) {
 			if createOnlyMode {

--- a/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/clusterspiffeid_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/client/fakes"
 	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/status"
+	"github.com/openshift/zero-trust-workload-identity-manager/pkg/controller/utils"
 	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +98,10 @@ func TestReconcileClusterSpiffeIDs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-oidc-discovery-provider",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fakeClient.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps.go
@@ -49,20 +49,30 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileConfigMap(ctx context.Co
 			return "", err
 		}
 		r.log.Info("Created ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
-	} else if err == nil && (utils.GenerateMapHash(existingOidcCm.Data) != utils.GenerateMapHash(cm.Data) ||
-		!equality.Semantic.DeepEqual(existingOidcCm.Labels, cm.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping ConfigMap update due to create-only mode", "Namespace", cm.Namespace, "Name", cm.Name)
-		} else {
-			cm.ResourceVersion = existingOidcCm.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, cm); err != nil {
-				r.log.Error(err, "Failed to update ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
-				statusMgr.AddCondition(ConfigMapAvailable, "SpireOIDCConfigMapCreationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", err
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingOidcCm) {
+			ownerErr := utils.NewOwnershipConflictError("ConfigMap", cm.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", cm.Name)
+			statusMgr.AddCondition(ConfigMapAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return "", ownerErr
+		}
+		if utils.GenerateMapHash(existingOidcCm.Data) != utils.GenerateMapHash(cm.Data) ||
+			!equality.Semantic.DeepEqual(existingOidcCm.Labels, cm.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping ConfigMap update due to create-only mode", "Namespace", cm.Namespace, "Name", cm.Name)
+			} else {
+				cm.ResourceVersion = existingOidcCm.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, cm); err != nil {
+					r.log.Error(err, "Failed to update ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
+					statusMgr.AddCondition(ConfigMapAvailable, "SpireOIDCConfigMapCreationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", err
+				}
+				r.log.Info("Updated ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
 			}
-			r.log.Info("Updated ConfigMap", "Namespace", cm.Namespace, "Name", cm.Name)
 		}
 	} else if err != nil {
 		r.log.Error(err, "Failed to get ConfigMap")

--- a/pkg/controller/spire-oidc-discovery-provider/configmaps_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/configmaps_test.go
@@ -98,6 +98,9 @@ func TestReconcileConfigMap(t *testing.T) {
 				Name:            "spire-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+				Labels: map[string]string{
+					utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+				},
 			},
 			Data: map[string]string{
 				"oidc-discovery-provider.conf": "old-config",
@@ -138,6 +141,9 @@ func TestReconcileConfigMap(t *testing.T) {
 				Name:            "spire-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+				Labels: map[string]string{
+					utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+				},
 			},
 			Data: map[string]string{
 				"oidc-discovery-provider.conf": "old-config",
@@ -172,6 +178,9 @@ func TestReconcileConfigMap(t *testing.T) {
 				Name:            "spire-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+				Labels: map[string]string{
+					utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+				},
 			},
 			Data: map[string]string{
 				"oidc-discovery-provider.conf": "old-config",

--- a/pkg/controller/spire-oidc-discovery-provider/deployments.go
+++ b/pkg/controller/spire-oidc-discovery-provider/deployments.go
@@ -41,19 +41,29 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileDeployment(ctx context.C
 			return err
 		}
 		r.log.Info("Created spire oidc discovery provider deployment")
-	} else if err == nil && needsUpdate(existingSpireOidcDeployment, *deployment) {
-		if createOnlyMode {
-			r.log.Info("Skipping Deployment update due to create-only mode")
-		} else {
-			deployment.ResourceVersion = existingSpireOidcDeployment.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, deployment); err != nil {
-				r.log.Error(err, "Failed to update spire oidc discovery provider deployment")
-				statusMgr.AddCondition(DeploymentAvailable, "SpireOIDCDeploymentUpdateFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return err
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSpireOidcDeployment) {
+			ownerErr := utils.NewOwnershipConflictError("Deployment", deployment.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", deployment.Name)
+			statusMgr.AddCondition(DeploymentAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
+		}
+		if needsUpdate(existingSpireOidcDeployment, *deployment) {
+			if createOnlyMode {
+				r.log.Info("Skipping Deployment update due to create-only mode")
+			} else {
+				deployment.ResourceVersion = existingSpireOidcDeployment.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, deployment); err != nil {
+					r.log.Error(err, "Failed to update spire oidc discovery provider deployment")
+					statusMgr.AddCondition(DeploymentAvailable, "SpireOIDCDeploymentUpdateFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return err
+				}
+				r.log.Info("Updated spire oidc discovery provider deployment")
 			}
-			r.log.Info("Updated spire oidc discovery provider deployment")
 		}
 	} else if err != nil {
 		r.log.Error(err, "Failed to get existing spire oidc discovery provider deployment")

--- a/pkg/controller/spire-oidc-discovery-provider/deployments_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/deployments_test.go
@@ -399,6 +399,9 @@ func TestReconcileDeployment(t *testing.T) {
 				Name:            "spire-spiffe-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+				Labels: map[string]string{
+					utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,
@@ -437,6 +440,9 @@ func TestReconcileDeployment(t *testing.T) {
 				Name:            "spire-spiffe-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+				Labels: map[string]string{
+					utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,
@@ -472,6 +478,9 @@ func TestReconcileDeployment(t *testing.T) {
 				Name:            "spire-spiffe-oidc-discovery-provider",
 				Namespace:       utils.GetOperatorNamespace(),
 				ResourceVersion: "123",
+				Labels: map[string]string{
+					utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,

--- a/pkg/controller/spire-oidc-discovery-provider/rbac.go
+++ b/pkg/controller/spire-oidc-discovery-provider/rbac.go
@@ -82,6 +82,16 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRole(ctx con
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Role", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("External cert Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -145,6 +155,16 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileExternalCertRoleBinding(
 
 		r.log.Info("Created external cert RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("RoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-oidc-discovery-provider/rbac_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/rbac_test.go
@@ -3,6 +3,7 @@ package spire_oidc_discovery_provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -39,11 +40,11 @@ func newTestStore() *testStore {
 }
 
 func (s *testStore) key(obj client.Object) string {
-	return obj.GetNamespace() + "/" + obj.GetName()
+	return fmt.Sprintf("%T/%s/%s", obj, obj.GetNamespace(), obj.GetName())
 }
 
 func (s *testStore) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-	k := key.Namespace + "/" + key.Name
+	k := fmt.Sprintf("%T/%s/%s", obj, key.Namespace, key.Name)
 	stored, ok := s.objects[k]
 	if !ok {
 		return kerrors.NewNotFound(rbacv1.Resource(""), key.Name)
@@ -303,7 +304,10 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels: map[string]string{
+								"old-label":                "old-value",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Rules: []rbacv1.PolicyRule{
 							{
@@ -345,7 +349,10 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels: map[string]string{
+								"old-label":                "old-value",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: "ztwim.openshift.io/v1alpha1",
@@ -487,6 +494,9 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels: map[string]string{
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Rules: []rbacv1.PolicyRule{
 							{
@@ -511,6 +521,9 @@ func TestReconcileExternalCertRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireOIDCExternalCertRoleName,
 						Namespace: utils.GetOperatorNamespace(),
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Rules: []rbacv1.PolicyRule{{
 						APIGroups:     []string{""},
@@ -627,7 +640,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels: map[string]string{
+								"old-label":                "old-value",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa", Namespace: "old-ns"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old-role"},
@@ -662,7 +678,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels: map[string]string{
+								"old-label":                "old-value",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: "ztwim.openshift.io/v1alpha1",
@@ -794,7 +813,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireOIDCExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old-label": "old-value"},
+							Labels: map[string]string{
+								"old-label":                "old-value",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa", Namespace: "old-ns"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old-role"},
@@ -813,7 +835,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireOIDCExternalCertRoleBindingName,
 						Namespace: utils.GetOperatorNamespace(),
-						Labels:    map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa", Namespace: "old-ns"}},
 					RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old-role"},

--- a/pkg/controller/spire-oidc-discovery-provider/routes.go
+++ b/pkg/controller/spire-oidc-discovery-provider/routes.go
@@ -59,6 +59,13 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileRoute(ctx context.Contex
 					metav1.ConditionFalse)
 				return err
 			}
+		} else if !utils.IsResourceManagedByOperator(&existingRoute) {
+			ownerErr := utils.NewOwnershipConflictError("Route", route.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", route.Name)
+			statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
 		} else if checkRouteConflict(&existingRoute, route) {
 			r.log.Info("Found conflict in routes, updating route")
 			route.ResourceVersion = existingRoute.ResourceVersion

--- a/pkg/controller/spire-oidc-discovery-provider/routes_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/routes_test.go
@@ -937,6 +937,9 @@ func TestReconcileRoute_UpdateSuccess(t *testing.T) {
 			Name:            "spire-oidc-discovery-provider",
 			Namespace:       utils.GetOperatorNamespace(),
 			ResourceVersion: "123",
+			Labels: map[string]string{
+				utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+			},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "old.example.com", // Different host to trigger update
@@ -983,6 +986,9 @@ func TestReconcileRoute_UpdateError(t *testing.T) {
 			Name:            "spire-oidc-discovery-provider",
 			Namespace:       utils.GetOperatorNamespace(),
 			ResourceVersion: "123",
+			Labels: map[string]string{
+				utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+			},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "old.example.com", // Different host to trigger update
@@ -1027,6 +1033,9 @@ func TestReconcileRoute_CreateOnlyMode(t *testing.T) {
 			Name:            "spire-oidc-discovery-provider",
 			Namespace:       utils.GetOperatorNamespace(),
 			ResourceVersion: "123",
+			Labels: map[string]string{
+				utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+			},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "old.example.com", // Different host to trigger update

--- a/pkg/controller/spire-oidc-discovery-provider/service.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service.go
@@ -60,6 +60,16 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileService(ctx context.Cont
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Service", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Service exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-oidc-discovery-provider/service_account.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account.go
@@ -60,6 +60,16 @@ func (r *SpireOidcDiscoveryProviderReconciler) reconcileServiceAccount(ctx conte
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ServiceAccount", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_account_test.go
@@ -178,6 +178,9 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -205,7 +208,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -234,7 +240,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/spire-oidc-discovery-provider/service_test.go
+++ b/pkg/controller/spire-oidc-discovery-provider/service_test.go
@@ -191,6 +191,9 @@ func TestReconcileService(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -218,7 +221,10 @@ func TestReconcileService(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -248,7 +254,10 @@ func TestReconcileService(t *testing.T) {
 						Name:            "spire-spiffe-oidc-discovery-provider",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}

--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -80,19 +80,29 @@ func (r *SpireServerReconciler) reconcileSpireServerConfigMap(ctx context.Contex
 			return "", fmt.Errorf("failed to create ConfigMap: %w", err)
 		}
 		r.log.Info("Created spire server ConfigMap")
-	} else if err == nil && (existingSpireServerCM.Data["server.conf"] != spireServerConfigMap.Data["server.conf"] ||
-		!equality.Semantic.DeepEqual(existingSpireServerCM.Labels, spireServerConfigMap.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping ConfigMap update due to create-only mode")
-		} else {
-			spireServerConfigMap.ResourceVersion = existingSpireServerCM.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireServerConfigMap); err != nil {
-				statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSpireServerCM) {
+			ownerErr := utils.NewOwnershipConflictError("ConfigMap", spireServerConfigMap.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", spireServerConfigMap.Name)
+			statusMgr.AddCondition(ServerConfigMapAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return "", ownerErr
+		}
+		if existingSpireServerCM.Data["server.conf"] != spireServerConfigMap.Data["server.conf"] ||
+			!equality.Semantic.DeepEqual(existingSpireServerCM.Labels, spireServerConfigMap.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping ConfigMap update due to create-only mode")
+			} else {
+				spireServerConfigMap.ResourceVersion = existingSpireServerCM.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireServerConfigMap); err != nil {
+					statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+				}
+				r.log.Info("Updated ConfigMap with new config")
 			}
-			r.log.Info("Updated ConfigMap with new config")
 		}
 	} else if err != nil {
 		statusMgr.AddCondition(ServerConfigMapAvailable, "SpireServerConfigMapGenerationFailed",
@@ -146,20 +156,30 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerConfigMap(ctx con
 			return "", fmt.Errorf("failed to create ConfigMap: %w", err)
 		}
 		r.log.Info("Created spire controller manager ConfigMap")
-	} else if err == nil && (existingSpireControllerManagerCM.Data["controller-manager-config.yaml"] != spireControllerManagerConfigMap.Data["controller-manager-config.yaml"] ||
-		!equality.Semantic.DeepEqual(existingSpireControllerManagerCM.Labels, spireControllerManagerConfigMap.Labels)) {
-		if createOnlyMode {
-			r.log.Info("Skipping spire controller manager ConfigMap update due to create-only mode")
-		} else {
-			spireControllerManagerConfigMap.ResourceVersion = existingSpireControllerManagerCM.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, spireControllerManagerConfigMap); err != nil {
-				statusMgr.AddCondition(ControllerManagerConfigAvailable, "SpireControllerManagerConfigMapGenerationFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return "", fmt.Errorf("failed to update ConfigMap: %w", err)
-			}
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSpireControllerManagerCM) {
+			ownerErr := utils.NewOwnershipConflictError("ConfigMap", spireControllerManagerConfigMap.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", spireControllerManagerConfigMap.Name)
+			statusMgr.AddCondition(ControllerManagerConfigAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return "", ownerErr
 		}
-		r.log.Info("Updated ConfigMap with new config")
+		if existingSpireControllerManagerCM.Data["controller-manager-config.yaml"] != spireControllerManagerConfigMap.Data["controller-manager-config.yaml"] ||
+			!equality.Semantic.DeepEqual(existingSpireControllerManagerCM.Labels, spireControllerManagerConfigMap.Labels) {
+			if createOnlyMode {
+				r.log.Info("Skipping spire controller manager ConfigMap update due to create-only mode")
+			} else {
+				spireControllerManagerConfigMap.ResourceVersion = existingSpireControllerManagerCM.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, spireControllerManagerConfigMap); err != nil {
+					statusMgr.AddCondition(ControllerManagerConfigAvailable, "SpireControllerManagerConfigMapGenerationFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return "", fmt.Errorf("failed to update ConfigMap: %w", err)
+				}
+			}
+			r.log.Info("Updated ConfigMap with new config")
+		}
 	} else if err != nil {
 		r.log.Error(err, "failed to update spire controller manager config map")
 		return "", err

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -1389,6 +1389,9 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Data: map[string]string{"server.conf": "old-config"},
 				}
@@ -1411,6 +1414,9 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Data: map[string]string{"server.conf": "old-config"},
 				}
@@ -1433,6 +1439,9 @@ func TestReconcileSpireServerConfigMap(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Data: map[string]string{"server.conf": "old-config"},
 				}
@@ -1560,6 +1569,9 @@ func TestReconcileSpireControllerManagerConfigMap(t *testing.T) {
 						Name:            "spire-controller-manager-config",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Data: map[string]string{"spire-controller-manager-config.yaml": "old-config"},
 				}
@@ -1582,6 +1594,9 @@ func TestReconcileSpireControllerManagerConfigMap(t *testing.T) {
 						Name:            "spire-controller-manager-config",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Data: map[string]string{"spire-controller-manager-config.yaml": "old-config"},
 				}

--- a/pkg/controller/spire-server/rbac.go
+++ b/pkg/controller/spire-server/rbac.go
@@ -114,6 +114,16 @@ func (r *SpireServerReconciler) reconcileClusterRole(ctx context.Context, server
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ClusterRole", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRole exists, skipping update due to create-only mode", "name", desired.Name)
@@ -177,6 +187,16 @@ func (r *SpireServerReconciler) reconcileClusterRoleBinding(ctx context.Context,
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ClusterRoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update
@@ -244,6 +264,16 @@ func (r *SpireServerReconciler) reconcileSpireBundleRole(ctx context.Context, se
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Role", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -307,6 +337,16 @@ func (r *SpireServerReconciler) reconcileSpireBundleRoleBinding(ctx context.Cont
 
 		r.log.Info("Created RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("RoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update
@@ -374,6 +414,16 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRole(ctx contex
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ClusterRole", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ClusterRole exists, skipping update due to create-only mode", "name", desired.Name)
@@ -437,6 +487,16 @@ func (r *SpireServerReconciler) reconcileControllerManagerClusterRoleBinding(ctx
 
 		r.log.Info("Created ClusterRoleBinding", "name", desired.Name)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ClusterRoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update
@@ -504,6 +564,16 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRole(ctx context.Context,
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Role", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -567,6 +637,16 @@ func (r *SpireServerReconciler) reconcileLeaderElectionRoleBinding(ctx context.C
 
 		r.log.Info("Created RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("RoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update
@@ -728,6 +808,16 @@ func (r *SpireServerReconciler) reconcileExternalCertRole(ctx context.Context, s
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Role", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("External cert Role exists, skipping update due to create-only mode", "name", desired.Name)
@@ -791,6 +881,16 @@ func (r *SpireServerReconciler) reconcileExternalCertRoleBinding(ctx context.Con
 
 		r.log.Info("Created external cert RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("RoleBinding", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(RBACAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/rbac_test.go
+++ b/pkg/controller/spire-server/rbac_test.go
@@ -456,7 +456,13 @@ func TestReconcileClusterRole(t *testing.T) {
 			server: createRBACTestServer(),
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
 				existingCR := &rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{Name: "spire-server", ResourceVersion: "123"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-server",
+						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
+					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cr, ok := obj.(*rbacv1.ClusterRole); ok {
@@ -482,7 +488,10 @@ func TestReconcileClusterRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -595,7 +604,10 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -622,7 +634,10 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -649,7 +664,10 @@ func TestReconcileClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-server",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -762,7 +780,10 @@ func TestReconcileSpireBundleRole(t *testing.T) {
 						Name:            "spire-bundle",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -864,7 +885,10 @@ func TestReconcileSpireBundleRoleBinding(t *testing.T) {
 						Name:            "spire-bundle",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1008,7 +1032,13 @@ func TestReconcileControllerManagerClusterRole(t *testing.T) {
 			server: createRBACTestServer(),
 			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
 				existingCR := &rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{Name: "spire-controller-manager", ResourceVersion: "123"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-controller-manager",
+						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
+					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if cr, ok := obj.(*rbacv1.ClusterRole); ok {
@@ -1116,7 +1146,10 @@ func TestReconcileControllerManagerClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1143,7 +1176,10 @@ func TestReconcileControllerManagerClusterRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1252,7 +1288,10 @@ func TestReconcileLeaderElectionRole(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1280,7 +1319,10 @@ func TestReconcileLeaderElectionRole(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1389,7 +1431,10 @@ func TestReconcileLeaderElectionRoleBinding(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1417,7 +1462,10 @@ func TestReconcileLeaderElectionRoleBinding(t *testing.T) {
 						Name:            "spire-controller-manager-leader-election",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -1723,6 +1771,9 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels: map[string]string{
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Rules: []rbacv1.PolicyRule{{
 							APIGroups:     []string{""},
@@ -1757,6 +1808,9 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels: map[string]string{
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 							OwnerReferences: []metav1.OwnerReference{{
 								APIVersion: "ztwim.openshift.io/v1alpha1",
 								Kind:       "SpireServer",
@@ -1859,6 +1913,9 @@ func TestReconcileExternalCertRole(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels: map[string]string{
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Rules: []rbacv1.PolicyRule{{
 							APIGroups:     []string{""},
@@ -1876,6 +1933,9 @@ func TestReconcileExternalCertRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireServerExternalCertRoleName,
 						Namespace: utils.GetOperatorNamespace(),
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Rules: []rbacv1.PolicyRule{{
 						APIGroups:     []string{""},
@@ -1972,7 +2032,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old": "label"},
+							Labels: map[string]string{
+								"old":                      "label",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old"},
@@ -1993,7 +2056,10 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
-							Labels:    map[string]string{"old": "label"},
+							Labels: map[string]string{
+								"old":                      "label",
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 							OwnerReferences: []metav1.OwnerReference{{
 								APIVersion: "ztwim.openshift.io/v1alpha1",
 								Kind:       "SpireServer",
@@ -2085,6 +2151,9 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      utils.SpireServerExternalCertRoleBindingName,
 							Namespace: utils.GetOperatorNamespace(),
+							Labels: map[string]string{
+								utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+							},
 						},
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa"}},
 						RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old"},
@@ -2098,6 +2167,9 @@ func TestReconcileExternalCertRoleBinding(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      utils.SpireServerExternalCertRoleBindingName,
 						Namespace: utils.GetOperatorNamespace(),
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "old-sa"}},
 					RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "old"},
@@ -2179,25 +2251,18 @@ func TestReconcileExternalCertRBAC(t *testing.T) {
 				},
 			},
 			setupObjects: func() []client.Object { return []client.Object{} },
-			setupClient:  func(store *testStore) customClient.CustomCtrlClient { return newFakeClient(store) },
-			expectError:  false,
+			setupClient: func(store *testStore) customClient.CustomCtrlClient {
+				fake := &fakes.FakeCustomCtrlClient{}
+				fake.GetReturns(kerrors.NewNotFound(rbacv1.Resource(""), ""))
+				fake.CreateReturns(nil)
+				return fake
+			},
+			expectError: false,
 			postTestChecks: func(t *testing.T, client customClient.CustomCtrlClient) {
-				role := &rbacv1.Role{}
-				err := client.Get(ctx, types.NamespacedName{
-					Name:      utils.SpireServerExternalCertRoleName,
-					Namespace: utils.GetOperatorNamespace(),
-				}, role)
-				if err != nil {
-					t.Errorf("Expected role to be created: %v", err)
-				}
-
-				rb := &rbacv1.RoleBinding{}
-				err = client.Get(ctx, types.NamespacedName{
-					Name:      utils.SpireServerExternalCertRoleBindingName,
-					Namespace: utils.GetOperatorNamespace(),
-				}, rb)
-				if err != nil {
-					t.Errorf("Expected rolebinding to be created: %v", err)
+				if fc, ok := client.(*fakes.FakeCustomCtrlClient); ok {
+					if fc.CreateCallCount() != 2 {
+						t.Errorf("Expected 2 Create calls (Role + RoleBinding), got %d", fc.CreateCallCount())
+					}
 				}
 			},
 		},

--- a/pkg/controller/spire-server/routes.go
+++ b/pkg/controller/spire-server/routes.go
@@ -128,6 +128,13 @@ func (r *SpireServerReconciler) reconcileRoute(ctx context.Context, server *v1al
 					metav1.ConditionFalse)
 				return err
 			}
+		} else if !utils.IsResourceManagedByOperator(&existingRoute) {
+			ownerErr := utils.NewOwnershipConflictError("Route", route.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", route.Name)
+			statusMgr.AddCondition(RouteAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
 		} else if checkFederationRouteConflict(&existingRoute, route) {
 			if createOnlyMode {
 				r.log.Info("Skipping federation route update due to create-only mode")

--- a/pkg/controller/spire-server/routes_test.go
+++ b/pkg/controller/spire-server/routes_test.go
@@ -470,7 +470,10 @@ func TestReconcileRoute(t *testing.T) {
 						Name:            "spire-server-federation",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: routev1.RouteSpec{Host: "old-host"},
 				}
@@ -498,7 +501,10 @@ func TestReconcileRoute(t *testing.T) {
 						Name:            "spire-server-federation",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: routev1.RouteSpec{Host: "old-host"},
 				}
@@ -526,7 +532,10 @@ func TestReconcileRoute(t *testing.T) {
 						Name:            "spire-server-federation",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old": "label"},
+						Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: routev1.RouteSpec{Host: "old-host"},
 				}

--- a/pkg/controller/spire-server/service.go
+++ b/pkg/controller/spire-server/service.go
@@ -75,6 +75,16 @@ func (r *SpireServerReconciler) reconcileSpireServerService(ctx context.Context,
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Service", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("Service exists, skipping update due to create-only mode", "name", desired.Name)
@@ -156,6 +166,16 @@ func (r *SpireServerReconciler) reconcileSpireControllerManagerService(ctx conte
 
 		r.log.Info("Created Service", "name", desired.Name, "namespace", desired.Namespace)
 		return nil
+	}
+
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("Service", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
 	}
 
 	// Resource exists, check if we need to update

--- a/pkg/controller/spire-server/service_account.go
+++ b/pkg/controller/spire-server/service_account.go
@@ -60,6 +60,16 @@ func (r *SpireServerReconciler) reconcileServiceAccount(ctx context.Context, ser
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ServiceAccount", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ServiceAccountAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ServiceAccount exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-server/service_account_test.go
+++ b/pkg/controller/spire-server/service_account_test.go
@@ -167,6 +167,9 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
+						Labels: map[string]string{
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -196,7 +199,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -226,7 +232,10 @@ func TestReconcileServiceAccount(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -239,6 +248,30 @@ func TestReconcileServiceAccount(t *testing.T) {
 			},
 			expectError:  true,
 			expectUpdate: true,
+		},
+		{
+			name: "ownership conflict - existing resource not managed by operator",
+			server: &v1alpha1.SpireServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			},
+			setupClient: func(fc *fakes.FakeCustomCtrlClient) {
+				existingSA := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "spire-server",
+						Namespace:       utils.GetOperatorNamespace(),
+						ResourceVersion: "123",
+						Labels:          map[string]string{"app": "other-app"},
+					},
+				}
+				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if sa, ok := obj.(*corev1.ServiceAccount); ok {
+						*sa = *existingSA
+					}
+					return nil
+				}
+			},
+			expectError:  true,
+			expectUpdate: false,
 		},
 		{
 			name: "set controller ref error",

--- a/pkg/controller/spire-server/service_test.go
+++ b/pkg/controller/spire-server/service_test.go
@@ -326,7 +326,10 @@ func TestReconcileSpireServerService(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -357,7 +360,10 @@ func TestReconcileSpireServerService(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -388,7 +394,10 @@ func TestReconcileSpireServerService(t *testing.T) {
 						Name:            "spire-server",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
 				}
@@ -513,7 +522,10 @@ func TestReconcileSpireControllerManagerService(t *testing.T) {
 						Name:            "spire-controller-manager-webhook",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2"},
 				}
@@ -544,7 +556,10 @@ func TestReconcileSpireControllerManagerService(t *testing.T) {
 						Name:            "spire-controller-manager-webhook",
 						Namespace:       utils.GetOperatorNamespace(),
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.2"},
 				}

--- a/pkg/controller/spire-server/statefulset.go
+++ b/pkg/controller/spire-server/statefulset.go
@@ -50,18 +50,28 @@ func (r *SpireServerReconciler) reconcileStatefulSet(ctx context.Context, server
 			return fmt.Errorf("failed to create StatefulSet: %w", err)
 		}
 		r.log.Info("Created spire server StatefulSet")
-	} else if err == nil && needsUpdate(existingSTS, *sts) {
-		if createOnlyMode {
-			r.log.Info("Skipping StatefulSet update due to create-only mode")
-		} else {
-			sts.ResourceVersion = existingSTS.ResourceVersion
-			if err = r.ctrlClient.Update(ctx, sts); err != nil {
-				statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetUpdateFailed",
-					err.Error(),
-					metav1.ConditionFalse)
-				return fmt.Errorf("failed to update StatefulSet: %w", err)
+	} else if err == nil {
+		if !utils.IsResourceManagedByOperator(&existingSTS) {
+			ownerErr := utils.NewOwnershipConflictError("StatefulSet", sts.Name)
+			r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", sts.Name)
+			statusMgr.AddCondition(StatefulSetAvailable, v1alpha1.ReasonFailed,
+				ownerErr.Error(),
+				metav1.ConditionFalse)
+			return ownerErr
+		}
+		if needsUpdate(existingSTS, *sts) {
+			if createOnlyMode {
+				r.log.Info("Skipping StatefulSet update due to create-only mode")
+			} else {
+				sts.ResourceVersion = existingSTS.ResourceVersion
+				if err = r.ctrlClient.Update(ctx, sts); err != nil {
+					statusMgr.AddCondition(StatefulSetAvailable, "SpireServerStatefulSetUpdateFailed",
+						err.Error(),
+						metav1.ConditionFalse)
+					return fmt.Errorf("failed to update StatefulSet: %w", err)
+				}
+				r.log.Info("Updated spire server StatefulSet")
 			}
-			r.log.Info("Updated spire server StatefulSet")
 		}
 	} else if err != nil {
 		r.log.Error(err, "failed to get spire server stateful set resource")

--- a/pkg/controller/spire-server/statefulset_test.go
+++ b/pkg/controller/spire-server/statefulset_test.go
@@ -929,7 +929,10 @@ func TestReconcileStatefulSet(t *testing.T) {
 				existingSts := &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "spire-server", Namespace: utils.GetOperatorNamespace(),
-						ResourceVersion: "123", Labels: map[string]string{"old": "label"},
+						ResourceVersion: "123", Labels: map[string]string{
+							"old":                      "label",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
 				}

--- a/pkg/controller/spire-server/webhook.go
+++ b/pkg/controller/spire-server/webhook.go
@@ -60,6 +60,16 @@ func (r *SpireServerReconciler) reconcileWebhook(ctx context.Context, server *v1
 		return nil
 	}
 
+	// Verify resource is managed by this operator before updating
+	if !utils.IsResourceManagedByOperator(existing) {
+		ownerErr := utils.NewOwnershipConflictError("ValidatingWebhookConfiguration", desired.Name)
+		r.log.Error(ownerErr, "cannot update resource not managed by operator", "name", desired.Name)
+		statusMgr.AddCondition(ValidatingWebhookAvailable, v1alpha1.ReasonFailed,
+			ownerErr.Error(),
+			metav1.ConditionFalse)
+		return ownerErr
+	}
+
 	// Resource exists, check if we need to update
 	if createOnlyMode {
 		r.log.V(1).Info("ValidatingWebhookConfiguration exists, skipping update due to create-only mode", "name", desired.Name)

--- a/pkg/controller/spire-server/webhook_test.go
+++ b/pkg/controller/spire-server/webhook_test.go
@@ -166,7 +166,10 @@ func TestReconcileWebhook(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager-webhook",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -195,7 +198,10 @@ func TestReconcileWebhook(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager-webhook",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -224,7 +230,10 @@ func TestReconcileWebhook(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "spire-controller-manager-webhook",
 						ResourceVersion: "123",
-						Labels:          map[string]string{"old-label": "old-value"},
+						Labels: map[string]string{
+							"old-label":                "old-value",
+							utils.AppManagedByLabelKey: utils.AppManagedByLabelValue,
+						},
 					},
 				}
 				fc.GetStub = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/controller/utils/errors.go
+++ b/pkg/controller/utils/errors.go
@@ -15,6 +15,8 @@ const (
 	RetryRequiredError ErrorReason = "RetryRequiredError"
 
 	MultipleInstanceError ErrorReason = "MultipleInstanceError"
+
+	OwnershipConflictError ErrorReason = "OwnershipConflictError"
 )
 
 type ReconcileError struct {
@@ -44,6 +46,14 @@ func NewMultipleInstanceError(err error) *ReconcileError {
 		Reason:  MultipleInstanceError,
 		Message: fmt.Sprint(err.Error()),
 		Err:     err,
+	}
+}
+
+func NewOwnershipConflictError(resourceKind, resourceName string) *ReconcileError {
+	return &ReconcileError{
+		Reason:  OwnershipConflictError,
+		Message: fmt.Sprintf("%s %q exists but is not managed by this operator", resourceKind, resourceName),
+		Err:     fmt.Errorf("resource %s %q exists but is not managed by this operator, skipping update to avoid overwriting", resourceKind, resourceName),
 	}
 }
 

--- a/pkg/controller/utils/errors_test.go
+++ b/pkg/controller/utils/errors_test.go
@@ -182,3 +182,24 @@ func TestReconcileErrorError(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", expected, err.Error())
 	}
 }
+
+func TestNewOwnershipConflictError(t *testing.T) {
+	err := NewOwnershipConflictError("ServiceAccount", "spire-server")
+	if err == nil {
+		t.Fatal("Expected non-nil error")
+	}
+	if err.Reason != OwnershipConflictError {
+		t.Errorf("Expected reason %s, got %s", OwnershipConflictError, err.Reason)
+	}
+	if err.Message == "" {
+		t.Error("Expected non-empty message")
+	}
+	if err.Err == nil {
+		t.Error("Expected non-nil wrapped error")
+	}
+
+	errStr := err.Error()
+	if errStr == "" {
+		t.Error("Expected non-empty error string")
+	}
+}

--- a/pkg/controller/utils/resource_comparison.go
+++ b/pkg/controller/utils/resource_comparison.go
@@ -18,6 +18,18 @@ import (
 	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 )
 
+// IsResourceManagedByOperator checks if the given resource is managed by this operator
+// by verifying the presence of the managed-by label. Returns false if the resource
+// exists but was not created by this operator, preventing accidental overwrites.
+func IsResourceManagedByOperator(obj client.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	val, exists := labels[AppManagedByLabelKey]
+	return exists && val == AppManagedByLabelValue
+}
+
 // ResourceNeedsUpdate determines if a resource needs to be updated based on its type
 // This checks labels, annotations, and type-specific fields
 func ResourceNeedsUpdate(existing, desired client.Object) bool {

--- a/pkg/controller/utils/resource_comparison_test.go
+++ b/pkg/controller/utils/resource_comparison_test.go
@@ -2671,3 +2671,87 @@ func TestSecurityContextConstraintsNeedsUpdate_AllScenarios(t *testing.T) {
 		})
 	}
 }
+
+func TestIsResourceManagedByOperator(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			name:     "nil labels",
+			labels:   nil,
+			expected: false,
+		},
+		{
+			name:     "empty labels",
+			labels:   map[string]string{},
+			expected: false,
+		},
+		{
+			name: "missing managed-by label",
+			labels: map[string]string{
+				"app": "some-app",
+			},
+			expected: false,
+		},
+		{
+			name: "wrong managed-by value",
+			labels: map[string]string{
+				AppManagedByLabelKey: "some-other-operator",
+			},
+			expected: false,
+		},
+		{
+			name: "correct managed-by label",
+			labels: map[string]string{
+				AppManagedByLabelKey: AppManagedByLabelValue,
+			},
+			expected: true,
+		},
+		{
+			name: "correct managed-by label with extra labels",
+			labels: map[string]string{
+				AppManagedByLabelKey:     AppManagedByLabelValue,
+				"app.kubernetes.io/name": "spire-server",
+				"custom-label":           "custom-value",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-sa",
+					Labels: tt.labels,
+				},
+			}
+			result := IsResourceManagedByOperator(obj)
+			if result != tt.expected {
+				t.Errorf("IsResourceManagedByOperator() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+
+	t.Run("works with different resource types", func(t *testing.T) {
+		managedLabels := map[string]string{
+			AppManagedByLabelKey: AppManagedByLabelValue,
+		}
+
+		clusterRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cr", Labels: managedLabels},
+		}
+		if !IsResourceManagedByOperator(clusterRole) {
+			t.Error("Expected ClusterRole to be managed")
+		}
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Labels: nil},
+		}
+		if IsResourceManagedByOperator(configMap) {
+			t.Error("Expected ConfigMap without labels to not be managed")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `IsResourceManagedByOperator` utility that checks the `app.kubernetes.io/managed-by` label to confirm a resource belongs to this operator before allowing updates
- Introduces `OwnershipConflictError` for clear error reporting when a resource is not owned by the operator
- Updates all reconcilers across spire-server, spire-agent, spiffe-csi-driver, and spire-oidc-discovery-provider controllers to validate ownership before performing any update operation
- Also applies the check in `CreateOrUpdateObject` on the client wrapper level

## Motivation

Resolves [SPIRE-344](https://redhat.atlassian.net/browse/SPIRE-344): The operator was overwriting resources that were not managed by it. If another application created a resource with a conflicting name, the operator's reconciliation loop would silently overwrite it. Now the operator checks the `app.kubernetes.io/managed-by` label and returns an error instead of overwriting unmanaged resources.

## Changes

| Commit | Scope |
|--------|-------|
| `feat(utils)` | `IsResourceManagedByOperator` + `OwnershipConflictError` + unit tests |
| `feat(client)` | Ownership check in `CreateOrUpdateObject` |
| `feat(operator)` | Ownership validation in all 24 reconciler source files |
| `test` | Updated all test fixtures with managed-by label + ownership conflict test cases |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/...` — all tests pass
- [x] New unit test `TestIsResourceManagedByOperator` covers nil/empty/missing/wrong/correct label scenarios
- [x] New unit test `TestNewOwnershipConflictError` validates error construction
- [x] New ownership conflict test case in `service_account_test.go` verifies updates are rejected when label is absent
- [x] All existing test fixtures updated to include managed-by label so they pass the ownership check

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the operator from overwriting existing resources it does not manage.
  * Reconciliation now reports ownership conflicts, marks affected components unavailable, and stops safely.
  * Managed resources continue to support existing create, update, and create-only behaviors.

* **Tests**
  * Expanded coverage for ownership validation across workloads, services, RBAC, routes, and configuration resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->