### PR TITLE
SPIRE-353: Fix duplicate "healthz" port name in spire-server StatefulSet

### DIFF
--- a/pkg/controller/spire-server/statefulset.go
+++ b/pkg/controller/spire-server/statefulset.go
@@ -175,17 +175,17 @@ func GenerateSpireServerStatefulSet(config *v1alpha1.SpireServerSpec,
 							},
 							Ports: []corev1.ContainerPort{
 								{Name: "grpc", ContainerPort: 8081, Protocol: corev1.ProtocolTCP},
-								{Name: "healthz", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+								{Name: "server-healthz", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
 							},
 							LivenessProbe: &corev1.Probe{
-								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/live", Port: intstr.FromString("healthz")}},
+								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/live", Port: intstr.FromString("server-healthz")}},
 								InitialDelaySeconds: 15,
 								PeriodSeconds:       60,
 								TimeoutSeconds:      3,
 								FailureThreshold:    2,
 							},
 							ReadinessProbe: &corev1.Probe{
-								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("healthz")}},
+								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("server-healthz")}},
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       5,
 							},
@@ -205,13 +205,13 @@ func GenerateSpireServerStatefulSet(config *v1alpha1.SpireServerSpec,
 							},
 							Ports: []corev1.ContainerPort{
 								{Name: "https", ContainerPort: 9443},
-								{Name: "healthz", ContainerPort: 8083},
+								{Name: "ctrlmgr-healthz", ContainerPort: 8083},
 							},
 							LivenessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("healthz")}},
+								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("ctrlmgr-healthz")}},
 							},
 							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("healthz")}},
+								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("ctrlmgr-healthz")}},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "spire-server-socket", MountPath: "/tmp/spire-server/private", ReadOnly: true},

--- a/pkg/controller/spire-server/statefulset_test.go
+++ b/pkg/controller/spire-server/statefulset_test.go
@@ -557,17 +557,17 @@ func createReferenceStatefulSet(config *v1alpha1.SpireServerSpec, spireServerCon
 							},
 							Ports: []corev1.ContainerPort{
 								{Name: "grpc", ContainerPort: 8081, Protocol: corev1.ProtocolTCP},
-								{Name: "healthz", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+								{Name: "server-healthz", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
 							},
 							LivenessProbe: &corev1.Probe{
-								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/live", Port: intstr.FromString("healthz")}},
+								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/live", Port: intstr.FromString("server-healthz")}},
 								InitialDelaySeconds: 15,
 								PeriodSeconds:       60,
 								TimeoutSeconds:      3,
 								FailureThreshold:    2,
 							},
 							ReadinessProbe: &corev1.Probe{
-								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("healthz")}},
+								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("server-healthz")}},
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       5,
 							},
@@ -588,13 +588,13 @@ func createReferenceStatefulSet(config *v1alpha1.SpireServerSpec, spireServerCon
 							},
 							Ports: []corev1.ContainerPort{
 								{Name: "https", ContainerPort: 9443},
-								{Name: "healthz", ContainerPort: 8083},
+								{Name: "ctrlmgr-healthz", ContainerPort: 8083},
 							},
 							LivenessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("healthz")}},
+								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("ctrlmgr-healthz")}},
 							},
 							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("healthz")}},
+								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromString("ctrlmgr-healthz")}},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "spire-server-socket", MountPath: "/tmp/spire-server/private", ReadOnly: true},
@@ -771,7 +771,7 @@ func TestGenerateSpireServerStatefulSetWithFederation(t *testing.T) {
 			name:                 "Without federation",
 			federation:           nil,
 			expectedVolumeCount:  5,
-			expectedPortCount:    2, // grpc, healthz only
+			expectedPortCount:    2, // grpc, server-healthz only
 			expectTLSVolume:      false,
 			expectFederationPort: false,
 		},
@@ -783,7 +783,7 @@ func TestGenerateSpireServerStatefulSetWithFederation(t *testing.T) {
 				},
 			},
 			expectedVolumeCount:  5, // No additional volume needed for https_spiffe
-			expectedPortCount:    3, // grpc, healthz, federation
+			expectedPortCount:    3, // grpc, server-healthz, federation
 			expectTLSVolume:      false,
 			expectFederationPort: true,
 		},


### PR DESCRIPTION
## Summary

- Renamed the duplicate `healthz` port in the spire-server StatefulSet to unique, container-prefixed names:
  - `spire-server` container: `healthz` → `server-healthz` (port 8080)
  - `spire-controller-manager` container: `healthz` → `ctrlmgr-healthz` (port 8083)
- Updated all liveness/readiness probe port references accordingly
- Updated unit test expectations to match the new port names

This eliminates the Kubernetes warning about duplicate port names and prevents potential issues with services and probes that select ports by name.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/controller/spire-server/...` passes
- [ ] Deploy and verify no duplicate port name warning from Kubernetes
- [ ] Verify health probes work correctly for both containers

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated health-check port names for the SPIRE server and controller manager.
  - Liveness and readiness checks continue using the same paths and timing, with improved port references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->