### PR TITLE
SPIRE-675: upgrade spire operand version from 1.13.3 to 1.13.6

### DIFF
--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -553,13 +553,13 @@ spec:
                 - name: OPERATOR_VERSION
                   value: 1.0.1
                 - name: RELATED_IMAGE_SPIRE_SERVER
-                  value: ghcr.io/spiffe/spire-server:1.13.3
+                  value: ghcr.io/spiffe/spire-server:1.13.6
                 - name: RELATED_IMAGE_SPIRE_AGENT
-                  value: ghcr.io/spiffe/spire-agent:1.13.3
+                  value: ghcr.io/spiffe/spire-agent:1.13.6
                 - name: RELATED_IMAGE_SPIFFE_CSI_DRIVER
                   value: ghcr.io/spiffe/spiffe-csi-driver:0.2.8
                 - name: RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER
-                  value: ghcr.io/spiffe/oidc-discovery-provider:1.13.3
+                  value: ghcr.io/spiffe/oidc-discovery-provider:1.13.6
                 - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
                   value: ghcr.io/spiffe/spire-controller-manager:0.6.4
                 - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR
@@ -644,13 +644,13 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: ghcr.io/spiffe/spire-server:1.13.3
+  - image: ghcr.io/spiffe/spire-server:1.13.6
     name: spire-server
-  - image: ghcr.io/spiffe/spire-agent:1.13.3
+  - image: ghcr.io/spiffe/spire-agent:1.13.6
     name: spire-agent
   - image: ghcr.io/spiffe/spiffe-csi-driver:0.2.8
     name: spiffe-csi-driver
-  - image: ghcr.io/spiffe/oidc-discovery-provider:1.13.3
+  - image: ghcr.io/spiffe/oidc-discovery-provider:1.13.6
     name: spire-oidc-discovery-provider
   - image: ghcr.io/spiffe/spire-controller-manager:0.6.4
     name: spire-controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,13 +79,13 @@ spec:
         - name: OPERATOR_VERSION
           value: 1.0.1
         - name: RELATED_IMAGE_SPIRE_SERVER
-          value: ghcr.io/spiffe/spire-server:1.13.3
+          value: ghcr.io/spiffe/spire-server:1.13.6
         - name: RELATED_IMAGE_SPIRE_AGENT
-          value: ghcr.io/spiffe/spire-agent:1.13.3
+          value: ghcr.io/spiffe/spire-agent:1.13.6
         - name: RELATED_IMAGE_SPIFFE_CSI_DRIVER
           value: ghcr.io/spiffe/spiffe-csi-driver:0.2.8
         - name: RELATED_IMAGE_SPIRE_OIDC_DISCOVERY_PROVIDER
-          value: ghcr.io/spiffe/oidc-discovery-provider:1.13.3
+          value: ghcr.io/spiffe/oidc-discovery-provider:1.13.6
         - name: RELATED_IMAGE_SPIRE_CONTROLLER_MANAGER
           value: ghcr.io/spiffe/spire-controller-manager:0.6.4
         - name: RELATED_IMAGE_NODE_DRIVER_REGISTRAR

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,8 +12,8 @@ var (
 
 	// Per-component versions (used for app.kubernetes.io/version labels)
 	SpiffeCsiVersion                  string = "0.2.8"
-	SpireAgentVersion                 string = "1.13.3"
+	SpireAgentVersion                 string = "1.13.6"
 	SpireControllerManagerVersion     string = "0.6.4"
-	SpireOIDCDiscoveryProviderVersion string = "1.13.3"
-	SpireServerVersion                string = "1.13.3"
+	SpireOIDCDiscoveryProviderVersion string = "1.13.6"
+	SpireServerVersion                string = "1.13.6"
 )


### PR DESCRIPTION
The intent of z version update is to rebase the latest security fixes.

Summary from release version notes

1. https://github.com/spiffe/spire/releases/tag/v1.13.4

- Fixed an issue in the http_challenge server node attestor plugin which allowed an attacker to make an SSRF attack. 
- Fixed an issue in the x509pop server node attestor plugin which allowed an attacker to make spire-server consume large and disproportionate amounts of CPU time for the node attestation process. 

2. https://github.com/spiffe/spire/releases/tag/v1.13.5

- Upgrade Go to 1.25.9 to address https://github.com/advisories/GHSA-xj38-jxc5-rppx, https://github.com/advisories/GHSA-7mr4-xjxg-34g6, https://github.com/advisories/GHSA-cqrx-3m42-5p5w, https://github.com/advisories/GHSA-cfp9-33rc-j74f, https://github.com/advisories/GHSA-x4jj-h2v8-hqqv, https://github.com/advisories/GHSA-jrg3-gfjw-hm96, https://github.com/advisories/GHSA-5w89-2c2x-6x66, https://github.com/advisories/GHSA-gjvh-7jh8-7xhm

3. https://github.com/spiffe/spire/releases/tag/v1.13.6

- Fixed an issue in the aws_iid server node attestor plugin where the RSA-2048 PKCS7 attestation path verified the PKCS7 signature against its embedded content but returned the identity document parsed from a separate, attacker-controlled field of the attestation data. 
- Fixed a TOCTOU issue in the join token data store path where concurrent attestations using the same token could each succeed because tx.Delete() did not report when no row was deleted. 
