### PR TITLE
[release-1.0.0]  SPIRE-617, OCPBUGS-112323: fix gcInterval to 10s to prevent spire-controller-manager High CPU usage

### DIFF
--- a/pkg/controller/spire-server/configmap.go
+++ b/pkg/controller/spire-server/configmap.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -24,7 +25,15 @@ import (
 	spiffev1alpha "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 )
 
-const defaultCaKeyType = "rsa-2048"
+const (
+	defaultCaKeyType = "rsa-2048"
+
+	// defaultControllerManagerGCInterval is the documented spire-controller-manager
+	// default. GCInterval is a non-pointer time.Duration without omitempty, so
+	// leaving it unset serializes as gcInterval: 0
+	// See https://github.com/spiffe/spire-controller-manager/issues/698
+	defaultControllerManagerGCInterval = 10 * time.Second
+)
 
 type ControllerManagerConfigYAML struct {
 	Kind                                  string            `json:"kind"`
@@ -516,6 +525,7 @@ func generateControllerManagerConfig(config *v1alpha1.SpireServerSpec, ztwim *v1
 				"local-path-storage",
 				"openshift-*",
 			},
+			GCInterval: defaultControllerManagerGCInterval,
 		},
 	}, nil
 }

--- a/pkg/controller/spire-server/configmaps_test.go
+++ b/pkg/controller/spire-server/configmaps_test.go
@@ -2,6 +2,7 @@ package spire_server
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -529,6 +530,7 @@ func TestGenerateSpireControllerManagerConfigYaml(t *testing.T) {
 				"entryIDPrefix: test-cluster":          "",
 				"spireServerSocketPath":                "/tmp/spire-server/private/api.sock",
 				"apiVersion: spire.spiffe.io/v1alpha1": "",
+				fmt.Sprintf("gcInterval: %d", int64(defaultControllerManagerGCInterval)): "",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Manual backport of #149 to release-1.0.0 (auto `/cherrypick release-1.0.0` failed due to conflicts)
- Hardcode spire-controller-manager gcInterval to 10s (no API change)

## Test plan
- [x] `go test ./pkg/controller/spire-server/ -run TestGenerateSpireControllerManagerConfigYaml`


Made with [Cursor](https://cursor.com)