### PR TITLE
SPIRE-676: Add federation SDS e2e tests with cross-cluster mTLS proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,11 @@ E2E_TIMEOUT ?= 45m
 test-e2e:
 	OPERATOR_NAMESPACE=zero-trust-workload-identity-manager go test ./test/e2e/ -v -timeout $(E2E_TIMEOUT)
 
+E2E_FEDERATION_TIMEOUT ?= 35m
+.PHONY: test-e2e-federation  # Run federation SDS e2e tests (requires KUBECONFIG_CLUSTER_B)
+test-e2e-federation:
+	OPERATOR_NAMESPACE=zero-trust-workload-identity-manager go test ./test/e2e/ -v -timeout $(E2E_FEDERATION_TIMEOUT) -ginkgo.label-filter="federation"
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	operatorv1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
 	"github.com/openshift/zero-trust-workload-identity-manager/test/e2e/utils"
@@ -35,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,6 +48,12 @@ var (
 	clientset    kubernetes.Interface
 	apiextClient apiextclient.Interface
 	configClient configv1.ConfigV1Interface
+
+	// Secondary cluster clients for federation tests (nil when KUBECONFIG_CLUSTER_B is unset)
+	cfgB          *rest.Config
+	k8sClientB    client.Client
+	clientsetB    kubernetes.Interface
+	configClientB configv1.ConfigV1Interface
 )
 
 var _ = BeforeSuite(func() {
@@ -59,6 +69,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1.AddToScheme(scheme))
 	utilruntime.Must(spiffev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(routev1.Install(scheme))
 
 	// Create controller-runtime client
 	k8sClient, err = client.New(cfg, client.Options{
@@ -77,6 +88,26 @@ var _ = BeforeSuite(func() {
 	// Create OpenShift config client
 	configClient, err = configv1.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred(), "failed to create OpenShift config client")
+
+	// Initialize secondary cluster clients for federation tests if KUBECONFIG_CLUSTER_B is set
+	kubeconfigB := os.Getenv("KUBECONFIG_CLUSTER_B")
+	if kubeconfigB != "" {
+		fmt.Fprintf(GinkgoWriter, "KUBECONFIG_CLUSTER_B is set, initializing Cluster B clients\n")
+
+		cfgB, err = clientcmd.BuildConfigFromFlags("", kubeconfigB)
+		Expect(err).NotTo(HaveOccurred(), "failed to build config from KUBECONFIG_CLUSTER_B")
+
+		k8sClientB, err = client.New(cfgB, client.Options{Scheme: scheme})
+		Expect(err).NotTo(HaveOccurred(), "failed to create Cluster B controller-runtime client")
+
+		clientsetB, err = kubernetes.NewForConfig(cfgB)
+		Expect(err).NotTo(HaveOccurred(), "failed to create Cluster B Kubernetes clientset")
+
+		configClientB, err = configv1.NewForConfig(cfgB)
+		Expect(err).NotTo(HaveOccurred(), "failed to create Cluster B OpenShift config client")
+	} else {
+		fmt.Fprintf(GinkgoWriter, "KUBECONFIG_CLUSTER_B not set, federation tests will be skipped\n")
+	}
 })
 
 // TestE2E runs the e2e test suite

--- a/test/e2e/federation_sds_test.go
+++ b/test/e2e/federation_sds_test.go
@@ -1,0 +1,460 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/zero-trust-workload-identity-manager/test/e2e/utils"
+	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Federation SDS E2E", Label("federation", "sds"), Ordered, func() {
+	var (
+		testCtx        context.Context
+		cancelCtx      context.CancelFunc
+		trustDomainA   string
+		trustDomainB   string
+		appsDomainA    string
+		appsDomainB    string
+		bundleRouteA   string
+		bundleRouteB   string
+		clusterSvcIPB  string
+	)
+
+	BeforeAll(func() {
+		if os.Getenv("KUBECONFIG_CLUSTER_B") == "" {
+			Skip("KUBECONFIG_CLUSTER_B not set, skipping federation tests")
+		}
+		Expect(k8sClientB).NotTo(BeNil(), "Cluster B client must be initialized")
+		Expect(clientsetB).NotTo(BeNil(), "Cluster B clientset must be initialized")
+
+		testCtx, cancelCtx = context.WithTimeout(context.Background(), 30*time.Minute)
+		DeferCleanup(cancelCtx)
+
+		By("Getting Cluster A apps domain")
+		baseDomainA, err := utils.GetClusterBaseDomain(testCtx, configClient)
+		Expect(err).NotTo(HaveOccurred(), "failed to get Cluster A base domain")
+		appsDomainA = fmt.Sprintf("apps.%s", baseDomainA)
+		trustDomainA = fmt.Sprintf("cluster-a.%s", appsDomainA)
+
+		By("Getting Cluster B apps domain")
+		baseDomainB, err := utils.GetClusterBaseDomain(testCtx, configClientB)
+		Expect(err).NotTo(HaveOccurred(), "failed to get Cluster B base domain")
+		appsDomainB = fmt.Sprintf("apps.%s", baseDomainB)
+		trustDomainB = fmt.Sprintf("cluster-b.%s", appsDomainB)
+
+		fmt.Fprintf(GinkgoWriter, "Cluster A: trustDomain=%s, appsDomain=%s\n", trustDomainA, appsDomainA)
+		fmt.Fprintf(GinkgoWriter, "Cluster B: trustDomain=%s, appsDomain=%s\n", trustDomainB, appsDomainB)
+	})
+
+	Context("Infrastructure", func() {
+		It("configures federation on Cluster A (ZTWIM + SpireServer with federation spec)", func() {
+			By("Creating ZeroTrustWorkloadIdentityManager on Cluster A")
+			utils.CreateFederationZTWIM(testCtx, k8sClient, trustDomainA, "cluster-a")
+
+			By("Creating SpireServer with federation on Cluster A")
+			utils.CreateFederationSpireServer(testCtx, k8sClient, trustDomainA, appsDomainA)
+
+			By("Creating SpireAgent on Cluster A")
+			utils.CreateFederationSpireAgent(testCtx, k8sClient)
+
+			By("Creating SpiffeCSIDriver on Cluster A")
+			utils.CreateFederationSpiffeCSIDriver(testCtx, k8sClient)
+		})
+
+		It("configures federation on Cluster B (ZTWIM + SpireServer with federation spec)", func() {
+			By("Creating ZeroTrustWorkloadIdentityManager on Cluster B")
+			utils.CreateFederationZTWIM(testCtx, k8sClientB, trustDomainB, "cluster-b")
+
+			By("Creating SpireServer with federation on Cluster B")
+			utils.CreateFederationSpireServer(testCtx, k8sClientB, trustDomainB, appsDomainB)
+
+			By("Creating SpireAgent on Cluster B")
+			utils.CreateFederationSpireAgent(testCtx, k8sClientB)
+
+			By("Creating SpiffeCSIDriver on Cluster B")
+			utils.CreateFederationSpiffeCSIDriver(testCtx, k8sClientB)
+		})
+
+		It("waits for SPIRE server/agent ready on both clusters", func() {
+			By("Waiting for SPIRE ready on Cluster A")
+			utils.WaitForSpireReady(testCtx, k8sClient, clientset, utils.FederationTimeout)
+
+			By("Waiting for SPIRE ready on Cluster B")
+			utils.WaitForSpireReady(testCtx, k8sClientB, clientsetB, utils.FederationTimeout)
+		})
+	})
+
+	Context("Federation Routes", func() {
+		It("creates federation routes on both clusters", func() {
+			By("Waiting for federation route on Cluster A")
+			Eventually(func() string {
+				route := &routev1.Route{}
+				err := k8sClient.Get(testCtx, types.NamespacedName{
+					Name:      utils.FederationRouteName,
+					Namespace: utils.OperatorNamespace,
+				}, route)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "waiting for federation route on Cluster A: %v\n", err)
+					return ""
+				}
+				return route.Spec.Host
+			}).WithTimeout(utils.ShortTimeout).WithPolling(utils.DefaultInterval).ShouldNot(BeEmpty(),
+				"federation route should have a host on Cluster A")
+
+			route := &routev1.Route{}
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{
+				Name:      utils.FederationRouteName,
+				Namespace: utils.OperatorNamespace,
+			}, route)).To(Succeed())
+			bundleRouteA = route.Spec.Host
+			fmt.Fprintf(GinkgoWriter, "Cluster A federation route: %s\n", bundleRouteA)
+
+			By("Waiting for federation route on Cluster B")
+			Eventually(func() string {
+				routeB := &routev1.Route{}
+				err := k8sClientB.Get(testCtx, types.NamespacedName{
+					Name:      utils.FederationRouteName,
+					Namespace: utils.OperatorNamespace,
+				}, routeB)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "waiting for federation route on Cluster B: %v\n", err)
+					return ""
+				}
+				return routeB.Spec.Host
+			}).WithTimeout(utils.ShortTimeout).WithPolling(utils.DefaultInterval).ShouldNot(BeEmpty(),
+				"federation route should have a host on Cluster B")
+
+			routeB := &routev1.Route{}
+			Expect(k8sClientB.Get(testCtx, types.NamespacedName{
+				Name:      utils.FederationRouteName,
+				Namespace: utils.OperatorNamespace,
+			}, routeB)).To(Succeed())
+			bundleRouteB = routeB.Spec.Host
+			fmt.Fprintf(GinkgoWriter, "Cluster B federation route: %s\n", bundleRouteB)
+
+			Expect(bundleRouteA).NotTo(BeEmpty())
+			Expect(bundleRouteB).NotTo(BeEmpty())
+		})
+	})
+
+	Context("Bidirectional Federation", func() {
+		It("applies bidirectional ClusterFederatedTrustDomain", func() {
+			By("Creating ClusterFederatedTrustDomain on Cluster A pointing to Cluster B")
+			cftdA := &spiffev1alpha1.ClusterFederatedTrustDomain{
+				ObjectMeta: metav1.ObjectMeta{Name: "federation-cluster-b"},
+				Spec: spiffev1alpha1.ClusterFederatedTrustDomainSpec{
+					TrustDomain:       trustDomainB,
+					BundleEndpointURL: fmt.Sprintf("https://%s:%d", bundleRouteB, utils.FederationRoutePort),
+					BundleEndpointProfile: spiffev1alpha1.BundleEndpointProfile{
+						Type:             spiffev1alpha1.HTTPSSPIFFEProfileType,
+						EndpointSPIFFEID: fmt.Sprintf("spiffe://%s/spire/server", trustDomainB),
+					},
+				},
+			}
+			Expect(k8sClient.Create(testCtx, cftdA)).To(Succeed(),
+				"failed to create ClusterFederatedTrustDomain on Cluster A")
+			DeferCleanup(func(ctx context.Context) {
+				_ = k8sClient.Delete(ctx, cftdA)
+			})
+
+			By("Creating ClusterFederatedTrustDomain on Cluster B pointing to Cluster A")
+			cftdB := &spiffev1alpha1.ClusterFederatedTrustDomain{
+				ObjectMeta: metav1.ObjectMeta{Name: "federation-cluster-a"},
+				Spec: spiffev1alpha1.ClusterFederatedTrustDomainSpec{
+					TrustDomain:       trustDomainA,
+					BundleEndpointURL: fmt.Sprintf("https://%s:%d", bundleRouteA, utils.FederationRoutePort),
+					BundleEndpointProfile: spiffev1alpha1.BundleEndpointProfile{
+						Type:             spiffev1alpha1.HTTPSSPIFFEProfileType,
+						EndpointSPIFFEID: fmt.Sprintf("spiffe://%s/spire/server", trustDomainA),
+					},
+				},
+			}
+			Expect(k8sClientB.Create(testCtx, cftdB)).To(Succeed(),
+				"failed to create ClusterFederatedTrustDomain on Cluster B")
+			DeferCleanup(func(ctx context.Context) {
+				_ = k8sClientB.Delete(ctx, cftdB)
+			})
+		})
+
+		It("exchanges trust bundles over HTTPS federation", func() {
+			By("Waiting for federation bundles to propagate")
+			time.Sleep(utils.FederationBundlePropagation)
+
+			By("Verifying federated bundle on Cluster A agent")
+			Eventually(func() bool {
+				pods, err := clientset.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{
+					LabelSelector: utils.SpireAgentPodLabel,
+				})
+				if err != nil || len(pods.Items) == 0 {
+					return false
+				}
+				agentPod := pods.Items[0].Name
+				stdout, _, err := utils.ExecInPod(testCtx, utils.OperatorNamespace, agentPod, "spire-agent",
+					[]string{"/opt/spire/bin/spire-agent", "api", "fetch", "bundle",
+						"-socketPath", "unix:///tmp/spire-agent/public/spire-agent.sock"})
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "spire-agent bundle fetch on A failed: %v\n", err)
+					return false
+				}
+				hasFederatedBundle := strings.Contains(stdout, trustDomainB)
+				if !hasFederatedBundle {
+					fmt.Fprintf(GinkgoWriter, "Cluster A agent does not yet have bundle from B\n")
+				}
+				return hasFederatedBundle
+			}).WithTimeout(utils.FederationTimeout).WithPolling(30*time.Second).Should(BeTrue(),
+				"Cluster A should have federated bundle from Cluster B")
+
+			By("Verifying federated bundle on Cluster B agent")
+			Eventually(func() bool {
+				pods, err := clientsetB.CoreV1().Pods(utils.OperatorNamespace).List(testCtx, metav1.ListOptions{
+					LabelSelector: utils.SpireAgentPodLabel,
+				})
+				if err != nil || len(pods.Items) == 0 {
+					return false
+				}
+				agentPod := pods.Items[0].Name
+				stdout, _, err := utils.ExecInPodOnClusterB(testCtx, utils.OperatorNamespace, agentPod, "spire-agent",
+					[]string{"/opt/spire/bin/spire-agent", "api", "fetch", "bundle",
+						"-socketPath", "unix:///tmp/spire-agent/public/spire-agent.sock"})
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "spire-agent bundle fetch on B failed: %v\n", err)
+					return false
+				}
+				hasFederatedBundle := strings.Contains(stdout, trustDomainA)
+				if !hasFederatedBundle {
+					fmt.Fprintf(GinkgoWriter, "Cluster B agent does not yet have bundle from A\n")
+				}
+				return hasFederatedBundle
+			}).WithTimeout(utils.FederationTimeout).WithPolling(30*time.Second).Should(BeTrue(),
+				"Cluster B should have federated bundle from Cluster A")
+		})
+	})
+
+	Context("SDS Configuration", func() {
+		It("injects expected SDS config in spire-agent ConfigMap on both clusters", func() {
+			By("Checking spire-agent ConfigMap on Cluster A for SDS config")
+			cmA, err := clientset.CoreV1().ConfigMaps(utils.OperatorNamespace).Get(testCtx, utils.SpireAgentConfigMapName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get spire-agent ConfigMap on Cluster A")
+
+			agentConfA := cmA.Data[utils.SpireAgentConfigKey]
+			Expect(agentConfA).NotTo(BeEmpty(), "agent config should not be empty on Cluster A")
+			Expect(agentConfA).To(ContainSubstring("default_all_bundles_name"),
+				"Cluster A agent config should contain default_all_bundles_name")
+			Expect(agentConfA).To(ContainSubstring("ROOTCA"),
+				"Cluster A agent config default_all_bundles_name should be ROOTCA")
+			fmt.Fprintf(GinkgoWriter, "[PASS] Cluster A: SDS default_all_bundles_name=ROOTCA present\n")
+
+			By("Checking spire-agent ConfigMap on Cluster B for SDS config")
+			cmB, err := clientsetB.CoreV1().ConfigMaps(utils.OperatorNamespace).Get(testCtx, utils.SpireAgentConfigMapName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get spire-agent ConfigMap on Cluster B")
+
+			agentConfB := cmB.Data[utils.SpireAgentConfigKey]
+			Expect(agentConfB).NotTo(BeEmpty(), "agent config should not be empty on Cluster B")
+			Expect(agentConfB).To(ContainSubstring("default_all_bundles_name"),
+				"Cluster B agent config should contain default_all_bundles_name")
+			Expect(agentConfB).To(ContainSubstring("ROOTCA"),
+				"Cluster B agent config default_all_bundles_name should be ROOTCA")
+			fmt.Fprintf(GinkgoWriter, "[PASS] Cluster B: SDS default_all_bundles_name=ROOTCA present\n")
+		})
+
+		It("serves ROOTCA with local and federated bundles via agent SDS", func() {
+			By("Verifying default_bundle_name is null on Cluster A (routes ROOTCA to buildAll)")
+			cmA, err := clientset.CoreV1().ConfigMaps(utils.OperatorNamespace).Get(testCtx, utils.SpireAgentConfigMapName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			agentConfA := cmA.Data[utils.SpireAgentConfigKey]
+			Expect(agentConfA).To(ContainSubstring(`"default_bundle_name"`),
+				"should have default_bundle_name key")
+
+			By("Verifying default_bundle_name is null on Cluster B")
+			cmB, err := clientsetB.CoreV1().ConfigMaps(utils.OperatorNamespace).Get(testCtx, utils.SpireAgentConfigMapName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			agentConfB := cmB.Data[utils.SpireAgentConfigKey]
+			Expect(agentConfB).To(ContainSubstring(`"default_bundle_name"`),
+				"should have default_bundle_name key")
+		})
+	})
+
+	Context("Cross-cluster mTLS proof", func() {
+		BeforeAll(func() {
+			By("Setting up mTLS test namespace on Cluster B (server)")
+			utils.SetupFederationNamespace(testCtx, k8sClientB, utils.MTLSTestNamespaceB, utils.MTLSServerSAName)
+			DeferCleanup(func(ctx context.Context) {
+				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.MTLSTestNamespaceB}}
+				_ = k8sClientB.Delete(ctx, ns)
+			})
+
+			By("Creating ClusterSPIFFEID for server on Cluster B")
+			utils.CreateFederationClusterSPIFFEID(testCtx, k8sClientB,
+				"federation-mtls-server", utils.MTLSTestNamespaceB, utils.MTLSServerAppLabel)
+			DeferCleanup(func(ctx context.Context) {
+				cspiffeID := &spiffev1alpha1.ClusterSPIFFEID{ObjectMeta: metav1.ObjectMeta{Name: "federation-mtls-server"}}
+				_ = k8sClientB.Delete(ctx, cspiffeID)
+			})
+
+			By("Deploying mTLS server pod on Cluster B")
+			serverPod := utils.NewMTLSServerPod(utils.MTLSServerPodName, utils.MTLSTestNamespaceB, utils.MTLSServerSAName)
+			Expect(k8sClientB.Create(testCtx, serverPod)).To(Succeed())
+			utils.WaitForPodReady(testCtx, clientsetB, utils.MTLSServerPodName, utils.MTLSTestNamespaceB, utils.DefaultTimeout)
+			utils.WaitForSVIDsReadyOnClusterB(testCtx, utils.MTLSTestNamespaceB, utils.MTLSServerPodName, "tls-server", utils.DefaultTimeout)
+
+			By("Creating a Service for the mTLS server on Cluster B")
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mtls-server",
+					Namespace: utils.MTLSTestNamespaceB,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": utils.MTLSServerAppLabel},
+					Ports: []corev1.ServicePort{
+						{Name: "tls", Port: int32(utils.MTLSServerPort), Protocol: corev1.ProtocolTCP},
+					},
+				},
+			}
+			Expect(k8sClientB.Create(testCtx, svc)).To(Succeed())
+
+			By("Getting Cluster B service ClusterIP for direct access")
+			Eventually(func() string {
+				s := &corev1.Service{}
+				if err := k8sClientB.Get(testCtx, client.ObjectKeyFromObject(svc), s); err != nil {
+					return ""
+				}
+				return s.Spec.ClusterIP
+			}).WithTimeout(utils.ShortTimeout).WithPolling(utils.ShortInterval).ShouldNot(BeEmpty())
+			s := &corev1.Service{}
+			Expect(k8sClientB.Get(testCtx, client.ObjectKeyFromObject(svc), s)).To(Succeed())
+			clusterSvcIPB = s.Spec.ClusterIP
+
+			By("Setting up mTLS test namespace on Cluster A (client)")
+			utils.SetupFederationNamespace(testCtx, k8sClient, utils.MTLSTestNamespaceA, utils.MTLSClientSAName)
+			DeferCleanup(func(ctx context.Context) {
+				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.MTLSTestNamespaceA}}
+				_ = k8sClient.Delete(ctx, ns)
+			})
+
+			By("Creating ClusterSPIFFEID for client on Cluster A")
+			utils.CreateFederationClusterSPIFFEID(testCtx, k8sClient,
+				"federation-mtls-client", utils.MTLSTestNamespaceA, utils.MTLSClientAppLabel)
+			DeferCleanup(func(ctx context.Context) {
+				cspiffeID := &spiffev1alpha1.ClusterSPIFFEID{ObjectMeta: metav1.ObjectMeta{Name: "federation-mtls-client"}}
+				_ = k8sClient.Delete(ctx, cspiffeID)
+			})
+
+			By("Deploying mTLS client pod on Cluster A")
+			clientPod := utils.NewMTLSClientPod(utils.MTLSClientPodName, utils.MTLSTestNamespaceA, utils.MTLSClientSAName)
+			Expect(k8sClient.Create(testCtx, clientPod)).To(Succeed())
+			utils.WaitForPodReady(testCtx, clientset, utils.MTLSClientPodName, utils.MTLSTestNamespaceA, utils.DefaultTimeout)
+			utils.WaitForSVIDsReady(testCtx, utils.MTLSTestNamespaceA, utils.MTLSClientPodName, "tls-client", utils.DefaultTimeout)
+		})
+
+		It("establishes cross-cluster mTLS between client and server", func() {
+			By("Attempting mTLS connection from Cluster A client to Cluster B server via route")
+			serverEndpoint := bundleRouteB
+			if serverEndpoint == "" {
+				// Fallback: if federation route is same-cluster accessible, use service IP
+				serverEndpoint = clusterSvcIPB
+			}
+
+			// The client pod on Cluster A connects to the server on Cluster B.
+			// Since the clusters are separate, use the Route host (publicly accessible).
+			// The Route host resolves externally and the server's SPIRE cert covers it.
+			Eventually(func() error {
+				stdout, stderr, err := utils.AttemptMTLSConnection(
+					testCtx,
+					utils.MTLSTestNamespaceA,
+					utils.MTLSClientPodName,
+					bundleRouteB,
+					utils.FederationRoutePort,
+				)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "mTLS attempt failed: stdout=%s stderr=%s err=%v\n",
+						strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+					return fmt.Errorf("mTLS connection failed: %w", err)
+				}
+				if strings.Contains(stdout, "verify error") || strings.Contains(stdout, "EXIT_CODE=1") {
+					return fmt.Errorf("TLS verification error in output: %s", stdout)
+				}
+				fmt.Fprintf(GinkgoWriter, "[PASS] Cross-cluster mTLS handshake succeeded\n")
+				return nil
+			}).WithTimeout(utils.FederationTimeout).WithPolling(30*time.Second).Should(Succeed(),
+				"cross-cluster mTLS should succeed with federated trust bundles")
+		})
+
+		It("mTLS fails when federated trust is removed (negative control)", func() {
+			By("Deleting ClusterFederatedTrustDomain on Cluster A")
+			cftd := &spiffev1alpha1.ClusterFederatedTrustDomain{
+				ObjectMeta: metav1.ObjectMeta{Name: "federation-cluster-b"},
+			}
+			Expect(k8sClient.Delete(testCtx, cftd)).To(Succeed(),
+				"failed to delete ClusterFederatedTrustDomain on Cluster A")
+
+			By("Waiting for trust bundle to expire/refresh")
+			time.Sleep(utils.FederationBundlePropagation)
+
+			By("Attempting mTLS connection (should fail without federated trust)")
+			// After removing the trust domain, the client should no longer trust
+			// the server's certificate from Cluster B
+			Eventually(func() bool {
+				stdout, _, err := utils.AttemptMTLSConnection(
+					testCtx,
+					utils.MTLSTestNamespaceA,
+					utils.MTLSClientPodName,
+					bundleRouteB,
+					utils.FederationRoutePort,
+				)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "[EXPECTED] mTLS connection failed as expected: %v\n", err)
+					return true
+				}
+				if strings.Contains(stdout, "verify error") || strings.Contains(stdout, "EXIT_CODE=1") {
+					fmt.Fprintf(GinkgoWriter, "[EXPECTED] TLS verification error (federation removed): %s\n", stdout)
+					return true
+				}
+				fmt.Fprintf(GinkgoWriter, "mTLS still succeeding unexpectedly, waiting for bundle expiry...\n")
+				return false
+			}).WithTimeout(utils.FederationTimeout).WithPolling(30*time.Second).Should(BeTrue(),
+				"mTLS should fail after federated trust is removed")
+
+			By("Re-creating ClusterFederatedTrustDomain to restore state")
+			cftdRestore := &spiffev1alpha1.ClusterFederatedTrustDomain{
+				ObjectMeta: metav1.ObjectMeta{Name: "federation-cluster-b"},
+				Spec: spiffev1alpha1.ClusterFederatedTrustDomainSpec{
+					TrustDomain:       trustDomainB,
+					BundleEndpointURL: fmt.Sprintf("https://%s:%d", bundleRouteB, utils.FederationRoutePort),
+					BundleEndpointProfile: spiffev1alpha1.BundleEndpointProfile{
+						Type:             spiffev1alpha1.HTTPSSPIFFEProfileType,
+						EndpointSPIFFEID: fmt.Sprintf("spiffe://%s/spire/server", trustDomainB),
+					},
+				},
+			}
+			Expect(k8sClient.Create(testCtx, cftdRestore)).To(Succeed())
+		})
+	})
+})

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -61,4 +61,22 @@ const (
 	DefaultTimeout     = 5 * time.Minute
 	ShortTimeout       = 2 * time.Minute
 	TestContextTimeout = 10 * time.Minute
+
+	// Federation test constants
+	FederationTimeout           = 10 * time.Minute
+	FederationBundlePropagation = 3 * time.Minute
+	FederationRouteName         = "spire-server-federation"
+	FederationRoutePort         = 443
+
+	MTLSServerImage     = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+	MTLSServerPort      = 8443
+	MTLSTestNamespaceA  = "e2e-federation-mtls-a"
+	MTLSTestNamespaceB  = "e2e-federation-mtls-b"
+	MTLSServerPodName   = "mtls-server"
+	MTLSClientPodName   = "mtls-client"
+	MTLSServerSAName    = "mtls-server-sa"
+	MTLSClientSAName    = "mtls-client-sa"
+	MTLSServerAppLabel  = "federation-mtls-server"
+	MTLSClientAppLabel  = "federation-mtls-client"
+	MTLSServerRouteName = "mtls-server"
 )

--- a/test/e2e/utils/federation.go
+++ b/test/e2e/utils/federation.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	operatorv1alpha1 "github.com/openshift/zero-trust-workload-identity-manager/api/v1alpha1"
+	spiffev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FederationClusterInfo holds cluster-specific details discovered during federation setup.
+type FederationClusterInfo struct {
+	AppsDomain      string
+	TrustDomain     string
+	BundleEndpoint  string
+	FederationRoute string
+}
+
+// NewMTLSServerPod builds a pod that runs a TLS server using SPIRE-issued certificates.
+// The server uses openssl s_server to listen with mTLS (mutual TLS verification).
+func NewMTLSServerPod(name, namespace, saName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": MTLSServerAppLabel},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: saName,
+			Containers: []corev1.Container{
+				{
+					Name:  SpiffeHelperContainerName,
+					Image: SpiffeHelperImage,
+					Args:  []string{"-config", "/run/spiffe-helper/helper.conf"},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "spiffe-workload-api", MountPath: "/spiffe-workload-api", ReadOnly: true},
+						{Name: "certs", MountPath: "/certs"},
+						{Name: "spiffe-helper-config", MountPath: "/run/spiffe-helper", ReadOnly: true},
+					},
+					SecurityContext: restrictedSecurityContext(),
+				},
+				{
+					Name:  "tls-server",
+					Image: MTLSServerImage,
+					Command: []string{"sh", "-c", `
+while [ ! -f /certs/svid.pem ]; do sleep 2; done
+echo "Certs available, starting TLS server..."
+exec openssl s_server \
+  -cert /certs/svid.pem \
+  -key /certs/svid_key.pem \
+  -CAfile /certs/bundle.pem \
+  -Verify 1 \
+  -accept 8443 \
+  -www \
+  -quiet 2>&1 || sleep 3600
+`},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "certs", MountPath: "/certs"},
+					},
+					SecurityContext: restrictedSecurityContext(),
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "spiffe-workload-api", VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: "csi.spiffe.io", ReadOnly: ptr.To(true)}}},
+				{Name: "certs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "spiffe-helper-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: SpiffeHelperConfigMapName}}}},
+			},
+		},
+	}
+}
+
+// NewMTLSClientPod builds a pod that can act as a TLS client using SPIRE-issued certificates.
+func NewMTLSClientPod(name, namespace, saName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": MTLSClientAppLabel},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: saName,
+			Containers: []corev1.Container{
+				{
+					Name:  SpiffeHelperContainerName,
+					Image: SpiffeHelperImage,
+					Args:  []string{"-config", "/run/spiffe-helper/helper.conf"},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "spiffe-workload-api", MountPath: "/spiffe-workload-api", ReadOnly: true},
+						{Name: "certs", MountPath: "/certs"},
+						{Name: "spiffe-helper-config", MountPath: "/run/spiffe-helper", ReadOnly: true},
+					},
+					SecurityContext: restrictedSecurityContext(),
+				},
+				{
+					Name:    "tls-client",
+					Image:   MTLSServerImage,
+					Command: []string{"sleep", "3600"},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "certs", MountPath: "/certs"},
+					},
+					SecurityContext: restrictedSecurityContext(),
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "spiffe-workload-api", VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: "csi.spiffe.io", ReadOnly: ptr.To(true)}}},
+				{Name: "certs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "spiffe-helper-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: SpiffeHelperConfigMapName}}}},
+			},
+		},
+	}
+}
+
+// SetupFederationNamespace creates a namespace with proper labels for ClusterSPIFFEID matching
+// and the required resources (ServiceAccount, spiffe-helper ConfigMap).
+func SetupFederationNamespace(ctx context.Context, k8sClient client.Client, namespace, saName string) {
+	By(fmt.Sprintf("Creating federation test namespace %s", namespace))
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{"kubernetes.io/metadata.name": namespace},
+		},
+	}
+	Expect(k8sClient.Create(ctx, ns)).To(Succeed(), "failed to create namespace %s", namespace)
+
+	By(fmt.Sprintf("Creating ServiceAccount %s/%s", namespace, saName))
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace},
+	}
+	Expect(k8sClient.Create(ctx, sa)).To(Succeed(), "failed to create ServiceAccount %s/%s", namespace, saName)
+
+	By(fmt.Sprintf("Creating spiffe-helper ConfigMap in %s", namespace))
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: SpiffeHelperConfigMapName, Namespace: namespace},
+		Data:       map[string]string{"helper.conf": DefaultAttestationSpiffeHelperConfig().String()},
+	}
+	Expect(k8sClient.Create(ctx, cm)).To(Succeed(), "failed to create spiffe-helper ConfigMap in %s", namespace)
+}
+
+// CreateFederationClusterSPIFFEID creates a ClusterSPIFFEID for a federation test namespace.
+func CreateFederationClusterSPIFFEID(ctx context.Context, k8sClient client.Client, name, namespace, appLabel string) {
+	By(fmt.Sprintf("Creating ClusterSPIFFEID %s for namespace %s", name, namespace))
+	cspiffeID := &spiffev1alpha1.ClusterSPIFFEID{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: spiffev1alpha1.ClusterSPIFFEIDSpec{
+			SPIFFEIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}",
+			PodSelector:      &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/metadata.name": namespace},
+			},
+			ClassName: "zero-trust-workload-identity-manager-spire",
+		},
+	}
+	Expect(k8sClient.Create(ctx, cspiffeID)).To(Succeed(), "failed to create ClusterSPIFFEID %s", name)
+}
+
+// WaitForSpireReady waits for both SpireServer and SpireAgent to report Ready on a cluster.
+func WaitForSpireReady(ctx context.Context, k8sClient client.Client, clientset kubernetes.Interface, timeout time.Duration) {
+	By("Waiting for SpireServer to become Ready")
+	WaitForSpireServerConditions(ctx, k8sClient, "cluster", map[string]metav1.ConditionStatus{
+		"Ready": metav1.ConditionTrue,
+	}, timeout)
+
+	By("Waiting for SpireAgent to become Ready")
+	WaitForSpireAgentConditions(ctx, k8sClient, "cluster", map[string]metav1.ConditionStatus{
+		"Ready": metav1.ConditionTrue,
+	}, timeout)
+
+	By("Waiting for SPIRE Server StatefulSet to be ready")
+	WaitForStatefulSetReady(ctx, clientset, SpireServerStatefulSetName, OperatorNamespace, timeout)
+
+	By("Waiting for SPIRE Agent DaemonSet to be available")
+	WaitForDaemonSetAvailable(ctx, clientset, SpireAgentDaemonSetName, OperatorNamespace, timeout)
+}
+
+// CreateFederationSpireServer creates the SpireServer CR with federation config enabled.
+func CreateFederationSpireServer(ctx context.Context, k8sClient client.Client, trustDomain, appsDomain string) {
+	By("Creating SpireServer with federation enabled")
+	spireServer := &operatorv1alpha1.SpireServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: operatorv1alpha1.SpireServerSpec{
+			JwtIssuer:           fmt.Sprintf("https://oidc-discovery.%s", appsDomain),
+			CAValidity:          metav1.Duration{Duration: 24 * time.Hour},
+			DefaultX509Validity: metav1.Duration{Duration: 1 * time.Hour},
+			DefaultJWTValidity:  metav1.Duration{Duration: 5 * time.Minute},
+			CAKeyType:           "rsa-2048",
+			CASubject: operatorv1alpha1.CASubject{
+				CommonName:   "SPIRE CA",
+				Country:      "US",
+				Organization: "E2E Test",
+			},
+			Persistence: operatorv1alpha1.Persistence{
+				Size:       "1Gi",
+				AccessMode: "ReadWriteOnce",
+			},
+			Datastore: operatorv1alpha1.DataStore{
+				DatabaseType:     "sqlite3",
+				ConnectionString: "/run/spire/data/datastore.sqlite3",
+			},
+			Federation: &operatorv1alpha1.FederationConfig{
+				BundleEndpoint: operatorv1alpha1.BundleEndpointConfig{
+					Profile:     operatorv1alpha1.HttpsSpiffeProfile,
+					RefreshHint: 300,
+				},
+				ManagedRoute: "true",
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, spireServer)).To(Succeed(), "failed to create SpireServer with federation config")
+}
+
+// CreateFederationSpireAgent creates the SpireAgent CR for federation testing.
+func CreateFederationSpireAgent(ctx context.Context, k8sClient client.Client) {
+	By("Creating SpireAgent")
+	spireAgent := &operatorv1alpha1.SpireAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: operatorv1alpha1.SpireAgentSpec{
+			NodeAttestor: &operatorv1alpha1.NodeAttestor{
+				K8sPSATEnabled: "true",
+			},
+			WorkloadAttestors: &operatorv1alpha1.WorkloadAttestors{
+				K8sEnabled: "true",
+				WorkloadAttestorsVerification: &operatorv1alpha1.WorkloadAttestorsVerification{
+					Type: "auto",
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, spireAgent)).To(Succeed(), "failed to create SpireAgent")
+}
+
+// CreateFederationSpiffeCSIDriver creates the SpiffeCSIDriver CR for federation testing.
+func CreateFederationSpiffeCSIDriver(ctx context.Context, k8sClient client.Client) {
+	By("Creating SpiffeCSIDriver")
+	csiDriver := &operatorv1alpha1.SpiffeCSIDriver{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       operatorv1alpha1.SpiffeCSIDriverSpec{},
+	}
+	Expect(k8sClient.Create(ctx, csiDriver)).To(Succeed(), "failed to create SpiffeCSIDriver")
+}
+
+// CreateFederationZTWIM creates the ZeroTrustWorkloadIdentityManager CR for federation testing.
+func CreateFederationZTWIM(ctx context.Context, k8sClient client.Client, trustDomain, clusterName string) {
+	By(fmt.Sprintf("Creating ZeroTrustWorkloadIdentityManager with trustDomain=%s, clusterName=%s", trustDomain, clusterName))
+	ztwim := &operatorv1alpha1.ZeroTrustWorkloadIdentityManager{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: operatorv1alpha1.ZeroTrustWorkloadIdentityManagerSpec{
+			BundleConfigMap: "spire-bundle",
+			TrustDomain:     trustDomain,
+			ClusterName:     clusterName,
+		},
+	}
+	Expect(k8sClient.Create(ctx, ztwim)).To(Succeed(), "failed to create ZeroTrustWorkloadIdentityManager")
+}
+
+// AttemptMTLSConnection executes an openssl s_client command from the client pod to test mTLS.
+// Uses the default KUBECONFIG (Cluster A). Returns stdout, stderr, and error.
+func AttemptMTLSConnection(ctx context.Context, namespace, podName, serverHost string, serverPort int) (string, string, error) {
+	cmd := []string{
+		"sh", "-c",
+		fmt.Sprintf(
+			`echo "FEDERATION-MTLS-TEST" | timeout 15 openssl s_client -connect %s:%d -cert /certs/svid.pem -key /certs/svid_key.pem -CAfile /certs/bundle.pem -verify_return_error -quiet 2>&1; echo "EXIT_CODE=$?"`,
+			serverHost, serverPort,
+		),
+	}
+	return ExecInPod(ctx, namespace, podName, "tls-client", cmd)
+}
+
+// ExecInPodOnClusterB runs a command in a pod on Cluster B by setting KUBECONFIG_CLUSTER_B.
+func ExecInPodOnClusterB(ctx context.Context, namespace, podName, containerName string, command []string) (string, string, error) {
+	kubeconfigB := os.Getenv("KUBECONFIG_CLUSTER_B")
+	if kubeconfigB == "" {
+		return "", "", fmt.Errorf("KUBECONFIG_CLUSTER_B not set")
+	}
+	return ExecInPodWithKubeconfig(ctx, kubeconfigB, namespace, podName, containerName, command)
+}
+
+// WaitForSVIDsReady waits until SVID files appear in /certs/ of the specified pod container
+// using the default KUBECONFIG (Cluster A).
+func WaitForSVIDsReady(ctx context.Context, namespace, podName, containerName string, timeout time.Duration) {
+	By(fmt.Sprintf("Waiting for SVID files in pod %s/%s", namespace, podName))
+	Eventually(func() string {
+		stdout, _, err := ExecInPod(ctx, namespace, podName, containerName, []string{"ls", "/certs/"})
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "exec ls /certs/ in %s/%s failed: %v\n", namespace, podName, err)
+			return ""
+		}
+		return stdout
+	}).WithTimeout(timeout).WithPolling(DefaultInterval).Should(
+		And(
+			ContainSubstring("svid.pem"),
+			ContainSubstring("svid_key.pem"),
+			ContainSubstring("bundle.pem"),
+		), "SVID files should appear in /certs/ of %s/%s", namespace, podName)
+}
+
+// WaitForSVIDsReadyOnClusterB waits until SVID files appear in /certs/ on a Cluster B pod.
+func WaitForSVIDsReadyOnClusterB(ctx context.Context, namespace, podName, containerName string, timeout time.Duration) {
+	By(fmt.Sprintf("Waiting for SVID files in pod %s/%s on Cluster B", namespace, podName))
+	Eventually(func() string {
+		stdout, _, err := ExecInPodOnClusterB(ctx, namespace, podName, containerName, []string{"ls", "/certs/"})
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "exec ls /certs/ in %s/%s (Cluster B) failed: %v\n", namespace, podName, err)
+			return ""
+		}
+		return stdout
+	}).WithTimeout(timeout).WithPolling(DefaultInterval).Should(
+		And(
+			ContainSubstring("svid.pem"),
+			ContainSubstring("svid_key.pem"),
+			ContainSubstring("bundle.pem"),
+		), "SVID files should appear in /certs/ of %s/%s on Cluster B", namespace, podName)
+}
+
+// restrictedSecurityContext returns the standard restricted PSA-compatible security context.
+func restrictedSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		RunAsNonRoot:             ptr.To(true),
+		RunAsUser:                ptr.To(int64(1000)),
+		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -219,6 +219,41 @@ func ExecInPod(ctx context.Context, namespace, podName, containerName string, co
 	return stdoutBuf.String(), stderrBuf.String(), nil
 }
 
+// ExecInPodWithKubeconfig runs a command in a pod container targeting a specific cluster
+// via explicit KUBECONFIG path. Returns stdout, stderr, and error.
+func ExecInPodWithKubeconfig(ctx context.Context, kubeconfig, namespace, podName, containerName string, command []string) (stdout, stderr string, err error) {
+	cli := "oc"
+	if _, lookupErr := exec.LookPath("oc"); lookupErr != nil {
+		cli = "kubectl"
+	}
+
+	args := []string{"exec", podName, "-n", namespace, "-c", containerName, "--"}
+	args = append(args, command...)
+
+	cmd := exec.CommandContext(ctx, cli, args...)
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, "KUBECONFIG=") {
+			env[i] = "KUBECONFIG=" + kubeconfig
+			break
+		}
+	}
+	if kubeconfig != "" {
+		cmd.Env = append(env, "KUBECONFIG="+kubeconfig)
+	} else {
+		cmd.Env = env
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err = cmd.Run(); err != nil {
+		return stdoutBuf.String(), stderrBuf.String(), fmt.Errorf("exec %s %v: %w", cli, args, err)
+	}
+	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
 // ReadSVIDPEM reads /certs/svid.pem from the given pod container.
 func ReadSVIDPEM(ctx context.Context, namespace, podName, containerName string) (string, error) {
 	stdout, stderr, err := ExecInPod(ctx, namespace, podName, containerName, []string{"cat", "/certs/svid.pem"})


### PR DESCRIPTION
## Summary

- Moves federation SDS validation from `openshift/release` inline shell scripts into proper Ginkgo v2 e2e tests in the operator repo.
- Adds mandatory cross-cluster mTLS client/server proof to validate federation works at runtime (not just CR/route creation).
- Federation tests are conditionally executed via `KUBECONFIG_CLUSTER_B` env var — existing single-cluster e2e is unaffected.

## Changes

- **`test/e2e/federation_sds_test.go`**: Full Ginkgo test suite covering infrastructure setup, federation route creation, bidirectional `ClusterFederatedTrustDomain`, SDS config verification (`default_all_bundles_name=ROOTCA`), and cross-cluster mTLS with negative control.
- **`test/e2e/utils/federation.go`**: Multi-cluster helpers (mTLS pod builders, namespace setup, SVID readiness checks, Cluster B exec support).
- **`test/e2e/e2e_suite_test.go`**: Secondary cluster client initialization from `KUBECONFIG_CLUSTER_B`.
- **`test/e2e/utils/constants.go`**: Federation constants (timeouts, route names, mTLS resource names).
- **`test/e2e/utils/utils.go`**: `ExecInPodWithKubeconfig` for cross-cluster pod exec.
- **`Makefile`**: New `test-e2e-federation` target with `-ginkgo.label-filter="federation"`.

## Test plan

- [ ] Verify `go build ./test/e2e/...` and `go vet ./test/e2e/...` pass
- [ ] Verify existing e2e tests still pass (no regression from suite changes)
- [ ] Verify federation tests skip gracefully when `KUBECONFIG_CLUSTER_B` is not set
- [ ] Run `make test-e2e-federation` against two HyperShift clusters with ZTWIM installed

## Related

- Release repo PR: https://github.com/openshift/release/pull/83422 (will be updated to invoke `make test-e2e-federation`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end testing for bidirectional SPIRE federation across two Kubernetes clusters.
  * Added validation for trust-bundle propagation, cross-cluster mutual TLS, and trust removal and restoration scenarios.
  * Added support for executing test commands against a specified Kubernetes cluster.

* **Tests**
  * Added configurable federation test timeouts.
  * Federation tests are automatically skipped when the secondary cluster is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->