### PR TITLE
[release-1.1] NO-JIRA: Bump operator version from 1.1.0 to 1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.0
+VERSION ?= 1.1.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2026-06-03T12:11:19Z"
+    createdAt: "2026-08-24T12:24:10Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -235,7 +235,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v1.1.0
+  name: zero-trust-workload-identity-manager.v1.1.1
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -731,7 +731,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: zero-trust-workload-identity-manager
                 - name: OPERATOR_VERSION
-                  value: 1.1.0
+                  value: 1.1.1
                 - name: RELATED_IMAGE_SPIRE_SERVER
                   value: ghcr.io/spiffe/spire-server:1.14.7
                 - name: RELATED_IMAGE_SPIRE_AGENT
@@ -838,4 +838,4 @@ spec:
     name: node-driver-registrar
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container
-  version: 1.1.0
+  version: 1.1.1

--- a/bundle/zero-trust-workload-identity-manager.package.yaml
+++ b/bundle/zero-trust-workload-identity-manager.package.yaml
@@ -2,5 +2,5 @@
 packageName: zero-trust-workload-identity-manager
 channels:
 - name: stable-v1
-  currentCSV: zero-trust-workload-identity-manager.v1.1.0
+  currentCSV: zero-trust-workload-identity-manager.v1.1.1
 defaultChannel: stable-v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
         - name: OPERATOR_NAME
           value: zero-trust-workload-identity-manager
         - name: OPERATOR_VERSION
-          value: 1.1.0
+          value: 1.1.1
         - name: RELATED_IMAGE_SPIRE_SERVER
           value: ghcr.io/spiffe/spire-server:1.14.7
         - name: RELATED_IMAGE_SPIRE_AGENT

--- a/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v1.1.0
+  name: zero-trust-workload-identity-manager.v1.1.1
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -74,4 +74,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 1.1.0
+  version: 1.1.1

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ var (
 	SHORTCOMMIT string
 
 	// Operator version (informational)
-	OperatorVersion string = "1.1.0"
+	OperatorVersion string = "1.1.1"
 
 	// Per-component versions (used for app.kubernetes.io/version labels)
 	SpiffeCsiVersion                  string = "0.2.8"


### PR DESCRIPTION
## Summary
- Bump operator version from 1.1.0 to 1.1.1 on `release-1.1`
- Update source pins (`Makefile`, `pkg/version/version.go`, `config/manager/manager.yaml`, CSV base, `package.yaml`)
- Regenerate the OLM bundle CSV via `make bundle`

## Test plan
- [ ] Confirm remaining `1.1.0` hits are vendor/docs only
- [ ] Verify operator reports version 1.1.1 at runtime
- [ ] CI passes


Made with [Cursor](https://cursor.com)