### PR TITLE
SPIRE-519: Bump operator version to 1.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.1
+VERSION ?= 1.0.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=zero-trust-workload-identity-manager
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/zero-trust-workload-identity-manager
-    createdAt: "2026-04-16T11:28:02Z"
+    createdAt: "2026-08-25T07:02:24Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -235,7 +235,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v1.0.1
+  name: zero-trust-workload-identity-manager.v1.0.2
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -551,7 +551,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: zero-trust-workload-identity-manager
                 - name: OPERATOR_VERSION
-                  value: 1.0.1
+                  value: 1.0.2
                 - name: RELATED_IMAGE_SPIRE_SERVER
                   value: ghcr.io/spiffe/spire-server:1.13.6
                 - name: RELATED_IMAGE_SPIRE_AGENT
@@ -658,4 +658,4 @@ spec:
     name: node-driver-registrar
   - image: registry.access.redhat.com/ubi9:latest
     name: spiffe-csi-init-container
-  version: 1.0.1
+  version: 1.0.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,7 +77,7 @@ spec:
         - name: OPERATOR_NAME
           value: zero-trust-workload-identity-manager
         - name: OPERATOR_VERSION
-          value: 1.0.1
+          value: 1.0.2
         - name: RELATED_IMAGE_SPIRE_SERVER
           value: ghcr.io/spiffe/spire-server:1.13.6
         - name: RELATED_IMAGE_SPIRE_AGENT

--- a/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/zero-trust-workload-identity-manager.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: zero-trust-workload-identity-manager.v1.0.1
+  name: zero-trust-workload-identity-manager.v1.0.2
   namespace: zero-trust-workload-identity-manager
 spec:
   apiservicedefinitions: {}
@@ -74,4 +74,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 1.0.1
+  version: 1.0.2

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ var (
 	SHORTCOMMIT string
 
 	// Operator version (informational)
-	OperatorVersion string = "1.0.1"
+	OperatorVersion string = "1.0.2"
 
 	// Per-component versions (used for app.kubernetes.io/version labels)
 	SpiffeCsiVersion                  string = "0.2.8"


### PR DESCRIPTION
1. update the opertaor version from 1.0.1 to 1.0.2 in CSV